### PR TITLE
Support for multiple pgbouncer targets and versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+v1.0.0
+-- IMPORTANT NOTE: All objects in this extension are dropped and recreated as part of this update. Privileges ARE NOT preserved as part of this update, so please ensure privileges you have on these objects are preserved before upgrading so that they can be reapplied. Note that execution by PUBLIC on the admin functions is once again revoked by this update.
+
+-- Add support for gathering statistics from multiple pgBouncer targets
+  -- A new configuration table has been added to define the names of all FDW servers.
+  -- All views have an additional column to identify the pgBouncer target
+  -- All administrative command functions have had a parameter for the FDW server name added to them. These functions intentionally do not use the configuration table to avoid accidentally running an admin command on multiple servers.
+
+-- Add better support for multiple versions of pgBouncer. Support for 1.17 has been backported into this version of pgbouncer_fdw.
+
+
 v0.5
 -- Update to support pgBouncer 1.18.0. Note that as of v0.5, this extension requires at least version 1.18.0 of pgBouncer. If you still need to support an older version, v0.4 works with pgBouncer 1.16 and v0.3 works with older versions of pgBouncer. There are no other changes in this version other than a compatibility update.
 -- Several views are dropped and recreated as part of this update. Privileges should be preserved, but it is recommended to double-check them.

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,14 @@ EXTVERSION = $(shell grep default_version $(EXTENSION).control | \
 DATA = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))
 #DOCS = $(wildcard doc/*.md)
 PG_CONFIG = pg_config
-PG94 = $(shell $(PG_CONFIG) --version | egrep " 8\.| 9\.0| 9\.1| 9\.2| 9\.3" > /dev/null && echo no || echo yes)
 
-ifeq ($(PG94),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql
 
-sql/$(EXTENSION)--$(EXTVERSION).sql: $(sort $(wildcard sql/views/*.sql)) $(sort $(wildcard sql/functions/*.sql))
+sql/$(EXTENSION)--$(EXTVERSION).sql: $(sort $(wildcard sql/tables/*.sql)) $(sort $(wildcard sql/functions/*.sql)) $(sort $(wildcard sql/views/*.sql))
 	cat $^ > $@
 
 DATA = $(wildcard updates/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
-endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# pgBouncer Foreign Data Wrapper
+# PgBouncer Foreign Data Wrapper
 
 ## Introduction
 
-pgbouncer_fdw provides a direct SQL interface to the pgBouncer SHOW commands. It takes advantage of the dblink_fdw feature to provide a more typical, table-like interface to the current status of your pgBouncer server(s). This makes it easier to set up monitoring or other services that require direct access to pgBouncer statistics.
+pgbouncer_fdw provides a direct SQL interface to the PgBouncer SHOW commands. It takes advantage of the dblink_fdw feature to provide a more typical, table-like interface to the current status of your PgBouncer server(s). This makes it easier to set up monitoring or other services that require direct access to PgBouncer statistics.
 
 ## Requirements
 
  * PostgreSQL 11+ - https://www.postgresql.org
  * dblink (contrib module) - https://www.postgresql.org/docs/current/dblink.html
- * pgBouncer 1.17+ - https://pgbouncer.github.io
+ * PgBouncer 1.17+ - https://pgbouncer.github.io
 
 ## Installation
 
 ### Database Users
 
-For basic monitoring of statistics, whichever database role(s) you will be using in the user mapping below will have to be added to the `stats_users` list in the pgBouncer configuration (pgbouncer.ini). You will also need to add any of these roles to the pgBouncer `auth_users` file. The auth_query method in pgBouncer cannot be used to connect to the special `pgbouncer` database where the SHOW commands must be run. Ensure the role(s) used are able to connect to the special `pgbouncer` database and run the SHOW commands before setting up the FDW.
+For basic monitoring of statistics, whichever database role(s) you will be using in the user mapping below will have to be added to the `stats_users` list in the PgBouncer configuration (pgbouncer.ini). You will also need to add any of these roles to the PgBouncer `auth_users` file. The auth_query method in PgBouncer cannot be used to connect to the special `pgbouncer` database where the SHOW commands must be run. Ensure the role(s) used are able to connect to the special `pgbouncer` database and run the SHOW commands before setting up the FDW.
 
-For running of the command functions, roles will have to be added to the `admin_users` list in the pgBouncer configuration. It is not recommended that your monitoring roles also be given admin console access. It is recommended to have a separate database role for a separate user mapping to allow access to the pgBouncer to run these commands. 
+For running of the command functions, roles will have to be added to the `admin_users` list in the PgBouncer configuration. It is not recommended that your monitoring roles also be given admin console access. It is recommended to have a separate database role for a separate user mapping to allow access to the PgBouncer to run these commands. 
 
 ### Extension Setup
 
@@ -32,7 +32,7 @@ CREATE EXTENSION dblink;
 
 3. Create one or more FDW servers and a user mapping manually with your preferred credentials. 
 
-    a. If only a single pgBouncer server is the target, leave FDW the server name as `pgbouncer` to use the default configuration. This avoids needing to use the configuration table at all. Set the port(s) to whichever one pgBouncer itself is running on, NOT the postgres database. pgBouncer statistics are global so it only needs to be monitored from a single database. If you have multiple databases in your cluster, it is recommended to just install it to the default `postgres` database, or whichever one is being used as a global database that will never be dropped.
+    a. If only a single PgBouncer server is the target, leave FDW the server name as `pgbouncer` to use the default configuration. This avoids needing to use the configuration table at all. Set the port(s) to whichever one PgBouncer itself is running on, NOT the postgres database. PgBouncer statistics are global so it only needs to be monitored from a single database. If you have multiple databases in your cluster, it is recommended to just install it to the default `postgres` database, or whichever one is being used as a global database that will never be dropped.
 
     ```
     CREATE SERVER pgbouncer FOREIGN DATA WRAPPER dblink_fdw OPTIONS (host 'localhost',
@@ -60,9 +60,9 @@ CREATE EXTENSION dblink;
 ```
 CREATE USER MAPPING FOR PUBLIC SERVER pgbouncer OPTIONS (user 'ccp_monitoring', password 'mypassword');
 ```
-If you've configured multiple pgbouncer targets, ensure you've also set the user mappings for all pgBouncer targets.
+If you've configured multiple pgbouncer targets, ensure you've also set the user mappings for all PgBouncer targets.
 
-Optionally create a separate user mapping to allow admin command access. The example below sets the `pg_admin` role that exists in the PostgreSQL database to connect to the pgBouncer admin console as the role `pg_admin` which should be in the pgbouncer.ini `admin_users` list
+Optionally create a separate user mapping to allow admin command access. The example below sets the `pg_admin` role that exists in the PostgreSQL database to connect to the PgBouncer admin console as the role `pg_admin` which should be in the pgbouncer.ini `admin_users` list
 ```
 CREATE USER MAPPING FOR pgb_admin SERVER pgbouncer OPTIONS (user 'pgb_admin', password 'supersecretpassword');
 ```
@@ -89,9 +89,9 @@ GRANT SELECT ON pgbouncer_stats TO ccp_monitoring;
 GRANT SELECT ON pgbouncer_users TO ccp_monitoring;
 
 ```
-Please remember that if you are monitoring multiple pgBouncers, you may need to do these grants for additional FDW servers.
+Please remember that if you are monitoring multiple PgBouncers, you may need to do these grants for additional FDW servers.
 
-For added security, execution on the pgBouncer command functions has been revoked from public by default. You will need to explicitly grant execute privileges on the command functions to your pgBouncer admin role if they are being used.
+For added security, execution on the PgBouncer command functions has been revoked from public by default. You will need to explicitly grant execute privileges on the command functions to your PgBouncer admin role if they are being used.
 ```
 GRANT USAGE ON FOREIGN SERVER pgbouncer TO pgb_admin;
 
@@ -120,7 +120,7 @@ GRANT SELECT ON pgbouncer_users TO pgb_admin;
 ```
 
 ## Usage
-You should be able to query any of the pgBouncer views provided. For the meaning of the views, see the pgBouncer documentation (linked above). Not all views are provided due to recommendations from author (FDS) or duplication of data already provided by other views (STATS_TOTALS, STATS_AVERAGES, etc).
+You should be able to query any of the PgBouncer views provided. For the meaning of the views, see the PgBouncer documentation (linked above). Not all views are provided due to recommendations from author (FDS) or duplication of data already provided by other views (STATS_TOTALS, STATS_AVERAGES, etc).
 
 ```
 postgres=# select * from pgbouncer_pools;
@@ -164,7 +164,7 @@ pool_mode             | statement
 
 ## FAQ
 
-*Q: If connecting to multiple pgBouncer's, how does pgBouncer_fdw handle one or more of the target hosts being down while others are up?*
+*Q: If connecting to multiple PgBouncer's, how does PgBouncer_fdw handle one or more of the target hosts being down while others are up?*
 
 A: A warning is given for each target host that cannot be connected to. The warning contains the full context of the original error message to help with debugging.
 
@@ -179,7 +179,7 @@ postgres=# select * from pgbouncer_fdw_targets ;
 ```
 ```
 postgres=# select * from pgbouncer_clients;
-WARNING:  pgbouncer_fdw: Unable to establish connection to pgBouncer target host: pgbouncer2. Continuing to additional hosts.
+WARNING:  pgbouncer_fdw: Unable to establish connection to PgBouncer target host: pgbouncer2. Continuing to additional hosts.
 ORIGINAL ERROR: could not establish connection
 CONTEXT: SQL statement "SELECT 
         v_row.target_host AS pgbouncer_target_host
@@ -220,13 +220,13 @@ application_name      | app - 192.168.122.16:56574
 
 ```
 
-*Q: When supporting multiple versions of pgBouncer, how are new/old/renamed columns handled?*
+*Q: When supporting multiple versions of PgBouncer, how are new/old/renamed columns handled?*
 
-A: pgbouncer_fdw will return all columns for all supported versions of pgBouncer. This means that there may be columns being returned that have no data because that version of pgBouncer does not have that column.
+A: pgbouncer_fdw will return all columns for all supported versions of PgBouncer. This means that there may be columns being returned that have no data because that version of PgBouncer does not have that column.
 
-If a newer version of pgBouncer drops a column completely, pgbouncer_fdw will support it for a limited time with an empty value and evaluate a time period when support for versions with that old column will be deprecated.
+If a newer version of PgBouncer drops a column completely, pgbouncer_fdw will support it for a limited time with an empty value and evaluate a time period when support for versions with that old column will be deprecated.
 
-For example, the application_name column will show up if you are running pgBouncer 1.17, but it will have an empty string for a value.
+For example, the application_name column will show up if you are running PgBouncer 1.17, but it will have an empty string for a value.
 ```
 postgres=# select * from pgbouncer_clients;
 -[ RECORD 1 ]---------+---------------------------
@@ -251,5 +251,5 @@ tls                   |
 application_name      |
 ```
 
-For renamed columns, the newly named column will always be returned and the old column name will not be available no matter the version of pgBouncer you are running. For example, in the `pgbouncer_pools` view for the `SHOW POOLS` command, the old `cl_cancel_req` in v1.17 was renamed to `cl_waiting_cancel_req` in 1.18. This means that for pgBouncer 1.17, you can get the value of `cl_cancel_req` by looking at the value of `cl_waiting_cancel_req`.
+For renamed columns, the newly named column will always be returned and the old column name will not be available no matter the version of PgBouncer you are running. For example, in the `pgbouncer_pools` view for the `SHOW POOLS` command, the old `cl_cancel_req` in v1.17 was renamed to `cl_waiting_cancel_req` in 1.18. This means that for PgBouncer 1.17, you can get the value of `cl_cancel_req` by looking at the value of `cl_waiting_cancel_req`.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# pgbouncer Foreign Data Wrapper
+# pgBouncer Foreign Data Wrapper
 
 ## Introduction
 
-pgbouncer_fdw provides a direct SQL interface to the pgbouncer SHOW commands. It takes advantage of the dblink_fdw feature to provide a more typical, table-like interface to the current status of your pgbouncer server(s). This makes it easier to set up monitoring or other services that require direct access to pgbouncer statistics.
+pgbouncer_fdw provides a direct SQL interface to the pgBouncer SHOW commands. It takes advantage of the dblink_fdw feature to provide a more typical, table-like interface to the current status of your pgBouncer server(s). This makes it easier to set up monitoring or other services that require direct access to pgBouncer statistics.
 
 ## Requirements
 
- * PostgreSQL 9.4+ - https://www.postgresql.org
+ * PostgreSQL 11+ - https://www.postgresql.org
  * dblink (contrib module) - https://www.postgresql.org/docs/current/dblink.html
- * pgbouncer 1.16+ - https://pgbouncer.github.io
+ * pgBouncer 1.17+ - https://pgbouncer.github.io
 
 ## Installation
 
@@ -16,7 +16,7 @@ pgbouncer_fdw provides a direct SQL interface to the pgbouncer SHOW commands. It
 
 For basic monitoring of statistics, whichever database role(s) you will be using in the user mapping below will have to be added to the `stats_users` list in the pgBouncer configuration (pgbouncer.ini). You will also need to add any of these roles to the pgBouncer `auth_users` file. The auth_query method in pgBouncer cannot be used to connect to the special `pgbouncer` database where the SHOW commands must be run. Ensure the role(s) used are able to connect to the special `pgbouncer` database and run the SHOW commands before setting up the FDW.
 
-For running of the command functions, roles will have to be added to the `admin_users` list in the pgbouncer configuration. It is not recommended that your monitoring roles also be given admin console access. It is recommended to have a separate database role for a separate user mapping to allow access to the pgBouncer to run these commands. 
+For running of the command functions, roles will have to be added to the `admin_users` list in the pgBouncer configuration. It is not recommended that your monitoring roles also be given admin console access. It is recommended to have a separate database role for a separate user mapping to allow access to the pgBouncer to run these commands. 
 
 ### Extension Setup
 
@@ -30,9 +30,9 @@ make install
 CREATE EXTENSION dblink;
 ```
 
-3. Create one or more FDW servers and a user mapping manually first with your preferred credentials. 
+3. Create one or more FDW servers and a user mapping manually with your preferred credentials. 
 
-    a. If only a single pgBouncer server is the target, leave FDW the server name as `pgbouncer` to use the default configuration. This avoids needing to use the configuration table at all. Set the port(s) to whichever one pgbouncer itself is running on, NOT the postgres database. pgBouncer statistics are global so it only needs to be monitored from a single database. If you have multiple databases in your cluster, it is recommended to just install it to the default `postgres` database, or whichever one is being used as a global database that will never be dropped.
+    a. If only a single pgBouncer server is the target, leave FDW the server name as `pgbouncer` to use the default configuration. This avoids needing to use the configuration table at all. Set the port(s) to whichever one pgBouncer itself is running on, NOT the postgres database. pgBouncer statistics are global so it only needs to be monitored from a single database. If you have multiple databases in your cluster, it is recommended to just install it to the default `postgres` database, or whichever one is being used as a global database that will never be dropped.
 
     ```
     CREATE SERVER pgbouncer FOREIGN DATA WRAPPER dblink_fdw OPTIONS (host 'localhost',
@@ -50,6 +50,10 @@ CREATE EXTENSION dblink;
                                                                      dbname 'pgbouncer');
 
     INSERT INTO pgbouncer_fdw_targets (target_host) VALUES ('pgbouncer1'),('pgbouncer2');
+    ```
+    If you do not have an FDW server named `pgbouncer`, be sure to deactivate or remove that default entry in the configuration table.
+    ```
+    UPDATE pgbouncer_fdw_targets SET active = false WHERE target_host = 'pgbouncer';
     ```
 
 4. Create user mappings
@@ -116,34 +120,98 @@ GRANT SELECT ON pgbouncer_users TO pgb_admin;
 ```
 
 ## Usage
-You should be able to query any of the pgbouncer views provided. For the meaning of the views, see the pgbouncer documentation (linked above). Not all views are provided either due to recommendations from author (FDS) or duplication of other view data already provided (STATS_TOTALS, STATS_AVERAGES, etc).
+You should be able to query any of the pgBouncer views provided. For the meaning of the views, see the pgBouncer documentation (linked above). Not all views are provided either due to recommendations from author (FDS) or duplication of other view data already provided (STATS_TOTALS, STATS_AVERAGES, etc).
 
 ```
-postgres=> SELECT * FROM pgbouncer_pools;
--[ RECORD 1 ]---------
-database   | pgbouncer
-user       | pgbouncer
-cl_active  | 1
-cl_waiting | 0
-sv_active  | 0
-sv_idle    | 0
-sv_used    | 0
-sv_tested  | 0
-sv_login   | 0
-maxwait    | 0
-maxwait_us | 0
-pool_mode  | statement
--[ RECORD 2 ]---------
-database   | postgres
-user       | postgres
-cl_active  | 1
-cl_waiting | 0
-sv_active  | 1
-sv_idle    | 0
-sv_used    | 0
-sv_tested  | 0
-sv_login   | 0
-maxwait    | 0
-maxwait_us | 0
-pool_mode  | session
+postgres=# select * from pgbouncer_pools;
+-[ RECORD 1 ]---------+-----------
+pgbouncer_target_host | pgbouncer
+database              | pgbouncer
+user                  | pgbouncer
+cl_active             | 1
+cl_waiting            | 0
+cl_active_cancel_req  | 0
+cl_waiting_cancel_req | 0
+sv_active             | 0
+sv_active_cancel      | 0
+sv_being_canceled     | 0
+sv_idle               | 0
+sv_used               | 0
+sv_tested             | 0
+sv_login              | 0
+maxwait               | 0
+maxwait_us            | 0
+pool_mode             | statement
+-[ RECORD 2 ]---------+-----------
+pgbouncer_target_host | pgbouncer2
+database              | pgbouncer
+user                  | pgbouncer
+cl_active             | 1
+cl_waiting            | 0
+cl_active_cancel_req  | 0
+cl_waiting_cancel_req | 0
+sv_active             | 0
+sv_active_cancel      | 0
+sv_being_canceled     | 0
+sv_idle               | 0
+sv_used               | 0
+sv_tested             | 0
+sv_login              | 0
+maxwait               | 0
+maxwait_us            | 0
+pool_mode             | statement
 ```
+
+## FAQ
+
+*Q: If connecting to multiple pgBouncer's, how does pgBouncer_fdw handle one or more of the target hosts being down while others are up?*
+
+A: A warning is given for each target host that cannot be connected to. Hosts that are still up should have their metrics returned
+```
+postgres=# select * from pgbouncer_fdw_targets;
+ target_host | active 
+-------------+--------
+ pgbouncer   | t
+ pgbouncer2  | t
+
+postgres=# select * from pgbouncer_users;
+WARNING:  pgbouncer_fdw: Unable to establish connection to pgBouncer target host: pgbouncer2. Continuing to additional hosts.
+ pgbouncer_target_host |      name      | pool_mode 
+-----------------------+----------------+-----------
+ pgbouncer             | ccp_monitoring | 
+ pgbouncer             | pgbouncer      | 
+```
+
+*Q: When supporting multiple versions of pgBouncer, how are new/old/renamed columns handled?*
+
+A: pgbouncer_fdw will return all columns for all supported versions of pgBouncer. This means that there may be columns being returned that have no data because that version of pgBouncer did not have that column. This means older versions of pgBouncer will see columns that only exist in newer versions being returned by the FDW. They will just have zero'd out data. 
+
+If a newer version of pgBouncer drops a column completely, pgbouncer_fdw will support it for a limited time with an empty value and evaluate a time period when support for versions with that old column will be deprecated.
+
+For example, the application_name column will show up if you are running pgBouncer 1.17, but it will have an empty string for a value.
+```
+postgres=# select * from pgbouncer_clients;
+-[ RECORD 1 ]---------+---------------------------
+pgbouncer_target_host | pgbouncer
+type                  | C
+user                  | ccp_monitoring
+database              | pgbouncer
+state                 | active
+addr                  | 192.168.122.16
+port                  | 53050
+local_addr            | 192.168.122.13
+local_port            | 6432
+connect_time          | 2023-05-12 15:07:35-04
+request_time          | 2023-05-12 15:07:35-04
+wait                  | 0
+wait_us               | 0
+close_needed          | 0
+ptr                   | 0x15d8b00
+link                  | 
+remote_pid            | 0
+tls                   | 
+application_name      |
+```
+
+For renamed columns, the newly named column will always be returned and the old column name will not be available no matter the version of pgBouncer you are running. For example, in the `pgbouncer_pools` view for the `SHOW POOLS` command, the old `cl_cancel_req` in v1.17 was renamed to `cl_waiting_cancel_req` in 1.18. This means that for pgBouncer 1.17, you can get the value of `cl_canel_req` by looking at the value of `cl_waiting_cancel_req`.
+

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ pool_mode             | statement
 
 ## FAQ
 
-*Q: If connecting to multiple PgBouncer's, how does PgBouncer_fdw handle one or more of the target hosts being down while others are up?*
+*Q: If connecting to multiple PgBouncer's, how does `pgbouncer_fdw` handle one or more of the target hosts being down while others are up?*
 
 A: A warning is given for each target host that cannot be connected to. The warning contains the full context of the original error message to help with debugging.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ GRANT SELECT ON pgbouncer_users TO pgb_admin;
 ```
 
 ## Usage
-You should be able to query any of the pgBouncer views provided. For the meaning of the views, see the pgBouncer documentation (linked above). Not all views are provided either due to recommendations from author (FDS) or duplication of other view data already provided (STATS_TOTALS, STATS_AVERAGES, etc).
+You should be able to query any of the pgBouncer views provided. For the meaning of the views, see the pgBouncer documentation (linked above). Not all views are provided due to recommendations from author (FDS) or duplication of data already provided by other views (STATS_TOTALS, STATS_AVERAGES, etc).
 
 ```
 postgres=# select * from pgbouncer_pools;

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ application_name      | app - 192.168.122.16:56574
 
 *Q: When supporting multiple versions of pgBouncer, how are new/old/renamed columns handled?*
 
-A: pgbouncer_fdw will return all columns for all supported versions of pgBouncer. This means that there may be columns being returned that have no data because that version of pgBouncer did not have that column. This means older versions of pgBouncer will see columns that only exist in newer versions being returned by the FDW. They will just have zero'd out data. 
+A: pgbouncer_fdw will return all columns for all supported versions of pgBouncer. This means that there may be columns being returned that have no data because that version of pgBouncer does not have that column.
 
 If a newer version of pgBouncer drops a column completely, pgbouncer_fdw will support it for a limited time with an empty value and evaluate a time period when support for versions with that old column will be deprecated.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ CREATE USER MAPPING FOR PUBLIC SERVER pgbouncer OPTIONS (user 'ccp_monitoring', 
 ```
 If you've configured multiple pgbouncer targets, ensure you've also set the user mappings for all PgBouncer targets.
 
-Optionally create a separate user mapping to allow admin command access. The example below sets the `pg_admin` role that exists in the PostgreSQL database to connect to the PgBouncer admin console as the role `pg_admin` which should be in the pgbouncer.ini `admin_users` list
+Optionally create a separate user mapping to allow admin command access. The example below sets the `pgb_admin` role that exists in the PostgreSQL database to connect to the PgBouncer admin console as the role `pgb_admin` which should be in the pgbouncer.ini `admin_users` list
 ```
 CREATE USER MAPPING FOR pgb_admin SERVER pgbouncer OPTIONS (user 'pgb_admin', password 'supersecretpassword');
 ```

--- a/pgbouncer_fdw.control
+++ b/pgbouncer_fdw.control
@@ -1,4 +1,4 @@
-default_version = '0.5'
+default_version = '1.0.0'
 comment = 'Extension for querying pgbouncer stats from normal SQL views & running pgbouncer commands from normal SQL functions'
 requires = dblink
 relocatable = false

--- a/sql/functions/pgbouncer_fdw_functions.sql
+++ b/sql/functions/pgbouncer_fdw_functions.sql
@@ -1,121 +1,1232 @@
 
-CREATE FUNCTION @extschema@.pgbouncer_command_disable(p_dbname text) RETURNS void
+/**** VIEW FUNCTIONS ****/
+
+/*
+ * pgbouncer_version_func
+ */
+CREATE FUNCTION  @extschema@.pgbouncer_version_func(p_target_host text DEFAULT NULL) RETURNS TABLE
+(
+    pgbouncer_target_host text
+    , version_major int
+    , version_minor int
+    , version_patch int
+)
 LANGUAGE plpgsql
 AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row   record;
+    v_sql   text;
 BEGIN
-    PERFORM dblink_exec('pgbouncer', format('DISABLE %I', p_dbname));
+
+v_sql := 'SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active';
+IF p_target_host IS NOT NULL THEN
+    v_sql := v_sql || format(' AND target_host = %L', p_target_host);
+END IF;
+
+FOR v_row IN EXECUTE v_sql
+LOOP BEGIN
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , split_part(substring(version from '\d.+'), '.', 1)::int AS version_major
+        , split_part(substring(version from '\d.+'), '.', 2)::int AS version_minor
+        , split_part(substring(version from '\d.+'), '.', 3)::int AS version_patch
+    FROM dblink(v_row.target_host, 'show version') AS x
+    (   
+        version text
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_enable(p_dbname text) RETURNS void
+
+/*
+ * pgbouncer_clients_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_clients_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , "type" text
+    , "user" text
+    , database text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
+)
 LANGUAGE plpgsql
 AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
-    PERFORM dblink_exec('pgbouncer', format('ENABLE %I', p_dbname));
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+           v_row.target_host AS pgbouncer_target_host
+           , x."type"
+           , x."user"
+           , x.database
+           , x.state
+           , x.addr
+           , x.port
+           , x.local_addr
+           , x.local_port
+           , x.connect_time
+           , x.request_time
+           , x.wait
+           , x.wait_us
+           , x.close_needed
+           , x.ptr
+           , x.link
+           , x.remote_pid
+           , x.tls
+           , x.application_name
+        FROM dblink(v_row.target_host, 'show clients') AS x
+        (  "type" text
+           , "user" text
+           , database text
+           , state text
+           , addr text
+           , port int
+           , local_addr text
+           , local_port int
+           , connect_time timestamp with time zone
+           , request_time timestamp with time zone
+           , wait int
+           , wait_us int
+           , close_needed int
+           , ptr text
+           , link text
+           , remote_pid int
+           , tls text
+           , application_name text
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+        RETURN QUERY SELECT 
+           v_row.target_host AS pgbouncer_target_host
+           , x."type"
+           , x."user"
+           , x.database
+           , x.state
+           , x.addr
+           , x.port
+           , x.local_addr
+           , x.local_port
+           , x.connect_time
+           , x.request_time
+           , x.wait
+           , x.wait_us
+           , x.close_needed
+           , x.ptr
+           , x.link
+           , x.remote_pid
+           , x.tls
+           , '' AS application_name
+        FROM dblink(v_row.target_host, 'show clients') AS x
+        (  "type" text
+           , "user" text
+           , database text
+           , state text
+           , addr text
+           , port int
+           , local_addr text
+           , local_port int
+           , connect_time timestamp with time zone
+           , request_time timestamp with time zone
+           , wait int
+           , wait_us int
+           , close_needed int
+           , ptr text
+           , link text
+           , remote_pid int
+           , tls text
+        );
+    END IF;
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_kill(p_dbname text DEFAULT NULL) RETURNS void
+
+/*
+ * pgbouncer_config_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_config_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , key text
+    , value text
+    , "default" text
+    , changeable boolean
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.key
+        , x.value
+        , x."default"
+        , x.changeable
+    FROM dblink(v_row.target_host, 'show config') AS x
+    (   key text
+        , value text
+        , "default" text
+        , changeable boolean
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_databases_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , name text
+    , host text
+    , port int
+    , database text
+    , force_user text
+    , pool_size int
+    , min_pool_size int
+    , reserve_pool int
+    , pool_mode text
+    , max_connections int
+    , current_connections int
+    , paused int
+    , disabled int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.name
+        , x.host
+        , x.port
+        , x.database
+        , x.force_user
+        , x.pool_size
+        , x.min_pool_size
+        , x.reserve_pool
+        , x.pool_mode
+        , x.max_connections
+        , x.current_connections
+        , x.paused
+        , x.disabled
+    FROM dblink(v_row.target_host, 'show databases') AS x
+    (   
+        name text
+        , host text
+        , port int
+        , database text
+        , force_user text
+        , pool_size int
+        , min_pool_size int
+        , reserve_pool int
+        , pool_mode text
+        , max_connections int
+        , current_connections int
+        , paused int
+        , disabled int
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_dns_hosts_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_dns_hosts_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , hostname text
+    , ttl bigint
+    , addrs text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.hostname
+        , x.ttl
+        , x.addrs
+    FROM dblink(v_row.target_host, 'show dns_hosts') AS x
+    (   
+        hostname text
+        , ttl bigint
+        , addrs text
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_dns_zones_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_dns_zones_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , zonename text
+    , serial text
+    , count int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.zonename
+        , x.serial
+        , x.count
+    FROM dblink(v_row.target_host, 'show dns_zones') AS x
+    (   
+        zonename text
+        , serial text
+        , count int
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_lists_func
+ */ 
+CREATE FUNCTION @extschema@.pgbouncer_lists_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , list text
+    , items int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN;
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.list
+        , x.items
+    FROM dblink(v_row.target_host, 'show lists') AS x
+    (   
+        list text
+        , items int
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_pools_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_pools_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , database text
+    , "user" text
+    , cl_active int
+    , cl_waiting int
+    , cl_active_cancel_req int
+    , cl_waiting_cancel_req int
+    , sv_active int
+    , sv_active_cancel int
+    , sv_being_canceled int
+    , sv_idle int
+    , sv_used int
+    , sv_tested int
+    , sv_login int
+    , maxwait int
+    , maxwait_us int
+    , pool_mode text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+               v_row.target_host AS pgbouncer_target_host
+               , x.database
+               , x."user"
+               , x.cl_active
+               , x.cl_waiting
+               , x.cl_active_cancel_req
+               , x.cl_waiting_cancel_req
+               , x.sv_active
+               , x.sv_active_cancel
+               , x.sv_being_canceled
+               , x.sv_idle
+               , x.sv_used
+               , x.sv_tested
+               , x.sv_login
+               , x.maxwait
+               , x.maxwait_us
+               , x.pool_mode
+        FROM dblink(v_row.target_host, 'show pools') AS x
+        (   database text
+            , "user" text
+            , cl_active int
+            , cl_waiting int
+            , cl_active_cancel_req int
+            , cl_waiting_cancel_req int
+            , sv_active int
+            , sv_active_cancel int
+            , sv_being_canceled int
+            , sv_idle int
+            , sv_used int
+            , sv_tested int
+            , sv_login int
+            , maxwait int
+            , maxwait_us int
+            , pool_mode text
+        );
+    -- backward compatiblity floor is 1.17
+    -- old cl_cancel_req is sent as cl_waiting_cancel_req
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+        RETURN QUERY SELECT 
+               v_row.target_host AS pgbouncer_target_host
+               , x.database
+               , x."user"
+               , x.cl_active
+               , x.cl_waiting
+               , 0 AS cl_active_cancel_req
+               , x.cl_cancel_req AS cl_waiting_cancel_req
+               , x.sv_active
+               , 0 AS sv_active_cancel
+               , 0 AS sv_being_canceled
+               , x.sv_idle
+               , x.sv_used
+               , x.sv_tested
+               , x.sv_login
+               , x.maxwait
+               , x.maxwait_us
+               , x.pool_mode
+        FROM dblink(v_row.target_host, 'show pools') AS x
+        (   database text
+            , "user" text
+            , cl_active int
+            , cl_waiting int
+            , cl_cancel_req int
+            , sv_active int
+            , sv_idle int
+            , sv_used int
+            , sv_tested int
+            , sv_login int
+            , maxwait int
+            , maxwait_us int
+            , pool_mode text
+        );
+    END IF;
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_servers_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_servers_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , "type" text
+    , "user" text
+    , database text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , '' AS application_name
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+        );
+    END IF;
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_sockets_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_sockets_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , "type" text
+    , "user" text
+    , database text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
+    , recv_pos int
+    , pkt_pos int
+    , pkt_remain int
+    , send_pos int
+    , send_remain int
+    , pkt_avail int
+    , send_avail int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , '' AS application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+        );
+    END IF;
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+/*
+ * pgbouncer_stats_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , database text
+    , total_xact_count bigint
+    , total_query_count bigint
+    , total_received bigint
+    , total_sent bigint
+    , total_xact_time bigint
+    , total_query_time bigint
+    , total_wait_time bigint
+    , avg_xact_count bigint
+    , avg_query_count bigint
+    , avg_recv bigint
+    , avg_sent bigint
+    , avg_xact_time bigint
+    , avg_query_time bigint
+    , avg_wait_time bigint
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.database
+        , x.total_xact_count
+        , x.total_query_count
+        , x.total_received
+        , x.total_sent
+        , x.total_xact_time
+        , x.total_query_time
+        , x.total_wait_time
+        , x.avg_xact_count
+        , x.avg_query_count
+        , x.avg_recv
+        , x.avg_sent
+        , x.avg_xact_time
+        , x.avg_query_time
+        , x.avg_wait_time
+    FROM dblink(v_row.target_host, 'show stats') AS x
+    (   
+        database text
+        , total_xact_count bigint
+        , total_query_count bigint
+        , total_received bigint
+        , total_sent bigint
+        , total_xact_time bigint
+        , total_query_time bigint
+        , total_wait_time bigint
+        , avg_xact_count bigint
+        , avg_query_count bigint
+        , avg_recv bigint
+        , avg_sent bigint
+        , avg_xact_time bigint
+        , avg_query_time bigint
+        , avg_wait_time bigint
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+/*
+ * pgbouncer_users_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , name text
+    , pool_mode text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.name
+        , x.pool_mode
+    FROM dblink(v_row.target_host, 'show users') AS x
+    (   
+        name text
+        , pool_mode text
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+END
+$$;
+
+
+/**** ADMIN FUNCTIONS ****/
+
+CREATE FUNCTION @extschema@.pgbouncer_command_disable(p_dbname text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, format('DISABLE %I', p_dbname));
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_enable(p_dbname text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, format('ENABLE %I', p_dbname));
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_kill(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
     IF p_dbname IS NULL THEN
-        PERFORM dblink_exec('pgbouncer', 'KILL');
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'KILL');
     ELSE
-        PERFORM dblink_exec('pgbouncer', format('KILL %I', p_dbname));
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('KILL %I', p_dbname));
     END IF;
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_pause(p_dbname text DEFAULT NULL) RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_pause(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
     IF p_dbname IS NULL THEN
-        PERFORM dblink_exec('pgbouncer', 'PAUSE');
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'PAUSE');
     ELSE
-        PERFORM dblink_exec('pgbouncer', format('PAUSE %I', p_dbname));
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('PAUSE %I', p_dbname));
     END IF;
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_reconnect(p_dbname text DEFAULT NULL) RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_reconnect(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
     IF p_dbname IS NULL THEN
-        PERFORM dblink_exec('pgbouncer', 'RECONNECT');
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'RECONNECT');
     ELSE
-        PERFORM dblink_exec('pgbouncer', format('RECONNECT %I', p_dbname));
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('RECONNECT %I', p_dbname));
     END IF;
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_reload() RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_reload(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    PERFORM dblink_exec('pgbouncer', 'RELOAD');
+    PERFORM dblink_exec(p_pgbouncer_target_host, 'RELOAD');
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_resume(p_dbname text DEFAULT NULL) RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_resume(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
     IF p_dbname IS NULL THEN
-        PERFORM dblink_exec('pgbouncer', 'RESUME');
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'RESUME');
     ELSE
-        PERFORM dblink_exec('pgbouncer', format('RESUME %I', p_dbname));
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('RESUME %I', p_dbname));
     END IF;
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_set(p_name text, p_value text) RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_set(p_name text, p_value text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    PERFORM dblink_exec('pgbouncer', format('SET %s = %L', p_name, p_value));
+    PERFORM dblink_exec(p_pgbouncer_target_host, format('SET %s = %L', p_name, p_value));
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_shutdown() RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_shutdown(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    PERFORM dblink_exec('pgbouncer', 'shutdown');
+    PERFORM dblink_exec(p_pgbouncer_target_host, 'shutdown');
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_suspend() RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_suspend(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    PERFORM dblink_exec('pgbouncer', 'SUSPEND');
+    PERFORM dblink_exec(p_pgbouncer_target_host, 'SUSPEND');
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_wait_close(p_dbname text DEFAULT NULL) RETURNS void
+CREATE FUNCTION @extschema@.pgbouncer_command_wait_close(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
 LANGUAGE plpgsql
 AS $$
 BEGIN
     IF p_dbname IS NULL THEN
-        PERFORM dblink_exec('pgbouncer', 'WAIT_CLOSE');
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'WAIT_CLOSE');
     ELSE
-        PERFORM dblink_exec('pgbouncer', format('WAIT_CLOSE %I', p_dbname));
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('WAIT_CLOSE %I', p_dbname));
     END IF;
 END
 $$;
 
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_disable(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_enable( text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_kill(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_pause(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reconnect(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reload() FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_resume(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_set(text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_shutdown() FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_suspend() FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_wait_close(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_disable(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_enable(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_kill(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_pause(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reconnect(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reload(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_resume(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_set(text, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_shutdown(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_suspend(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_wait_close(text, text) FROM PUBLIC;
 

--- a/sql/functions/pgbouncer_fdw_functions.sql
+++ b/sql/functions/pgbouncer_fdw_functions.sql
@@ -471,7 +471,7 @@ BEGIN
 
 FOR v_row IN  
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN;
+LOOP BEGIN
 
     RETURN QUERY SELECT 
         v_row.target_host AS pgbouncer_target_host

--- a/sql/functions/pgbouncer_fdw_functions.sql
+++ b/sql/functions/pgbouncer_fdw_functions.sql
@@ -182,6 +182,8 @@ LOOP BEGIN
            , remote_pid int
            , tls text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN
@@ -617,6 +619,8 @@ LOOP BEGIN
             , maxwait_us int
             , pool_mode text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN
@@ -766,6 +770,8 @@ LOOP BEGIN
             , remote_pid int
             , tls text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN
@@ -949,6 +955,8 @@ LOOP BEGIN
             , pkt_avail int
             , send_avail int
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN

--- a/sql/tables/pgbouncer_fdw_tables.sql
+++ b/sql/tables/pgbouncer_fdw_tables.sql
@@ -1,0 +1,11 @@
+/*
+ * pgbouncer_fdw_targets
+ */
+CREATE TABLE @extschema@.pgbouncer_fdw_targets (
+    target_host text NOT NULL
+    , active boolean NOT NULL DEFAULT true
+    , CONSTRAINT pgbouncer_fdw_targets_pk PRIMARY KEY (target_host) );
+CREATE INDEX pgbouncer_fdw_targets_active_idx ON pgbouncer_fdw_targets (active);
+SELECT pg_catalog.pg_extension_config_dump('pgbouncer_fdw_targets', '');
+
+INSERT INTO @extschema@.pgbouncer_fdw_targets ( target_host ) VALUES ('pgbouncer');

--- a/sql/views/pgbouncer_fdw_views.sql
+++ b/sql/views/pgbouncer_fdw_views.sql
@@ -1,291 +1,181 @@
+CREATE VIEW @extschema@.pgbouncer_version AS
+    SELECT version_major
+        , version_minor
+        , version_patch
+    FROM @extschema@.pgbouncer_version_func();
+
+
 CREATE VIEW @extschema@.pgbouncer_clients AS
-    SELECT type
-           , "user"
-           , database
-           , state
-           , addr
-           , port
-           , local_addr
-           , local_port
-           , connect_time
-           , request_time
-           , wait
-           , wait_us
-           , close_needed
-           , ptr
-           , link
-           , remote_pid
-           , tls
-           , application_name
-    FROM dblink('pgbouncer', 'show clients') AS x
-    (   type text
-        , "user" text
-        , database text
-        , state text
-        , addr text
-        , port int
-        , local_addr text
-        , local_port int
-        , connect_time timestamp with time zone
-        , request_time timestamp with time zone
-        , wait int
-        , wait_us int
-        , close_needed int
-        , ptr text
-        , link text
-        , remote_pid int
-        , tls text
-        , application_name text
-    );
+    SELECT pgbouncer_target_host
+        , "type"
+        , "user"
+        , database
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+    FROM @extschema@.pgbouncer_clients_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_config AS
-    SELECT key
-          , value
-          , "default"
-          , changeable
-    FROM dblink('pgbouncer', 'show config') AS x
-    (   key text
-        , value text
-        , "default" text
-        , changeable boolean
-    );
+    SELECT pgbouncer_target_host
+        , key
+        , value
+        , "default"
+        , changeable
+    FROM @extschema@.pgbouncer_config_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_databases AS
-    SELECT name
-           , host
-           , port
-           , database
-           , force_user
-           , pool_size
-           , min_pool_size
-           , reserve_pool
-           , pool_mode
-           , max_connections
-           , current_connections
-           , paused
-           , disabled
-     FROM dblink('pgbouncer', 'show databases') AS x
-    (   name text
-        , host text
-        , port int
-        , database text
-        , force_user text
-        , pool_size int
-        , min_pool_size int
-        , reserve_pool int
-        , pool_mode text
-        , max_connections int
-        , current_connections int
-        , paused int
-        , disabled int
-    );
+    SELECT pgbouncer_target_host
+        , name
+        , host
+        , port
+        , database
+        , force_user
+        , pool_size
+        , min_pool_size
+        , reserve_pool
+        , pool_mode
+        , max_connections
+        , current_connections
+        , paused
+        , disabled
+     FROM @extschema@.pgbouncer_databases_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_dns_hosts AS
-    SELECT hostname
-           , ttl
-           , addrs
-    FROM dblink('pgbouncer', 'show dns_hosts') AS x
-    (   hostname text
-        , ttl bigint
-        , addrs text
-    );
+    SELECT pgbouncer_target_host
+        , hostname
+        , ttl
+        , addrs
+     FROM @extschema@.pgbouncer_dns_hosts_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_dns_zones AS
-    SELECT zonename
-           , serial
-           , count
-    FROM dblink('pgbouncer', 'show dns_zones') AS x
-    (   zonename text
-        , serial text
-        , count int
-    );
+    SELECT pgbouncer_target_host
+        zonename
+        , serial
+        , count
+     FROM @extschema@.pgbouncer_dns_zones_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_lists AS
-    SELECT list
-           , items
-    FROM dblink('pgbouncer', 'show lists') AS x
-    (   list text
+    SELECT pgbouncer_target_host
+        , list text
         , items int
-    );
+     FROM @extschema@.pgbouncer_lists_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_pools AS
-    SELECT database
-           , "user"
-           , cl_active
-           , cl_waiting
-           , cl_active_cancel_req
-           , cl_waiting_cancel_req
-           , sv_active
-           , sv_active_cancel
-           , sv_being_canceled
-           , sv_idle
-           , sv_used
-           , sv_tested
-           , sv_login
-           , maxwait
-           , maxwait_us
-           , pool_mode
-    FROM dblink('pgbouncer', 'show pools') AS x
-    (   database text
-        , "user" text
-        , cl_active int
-        , cl_waiting int
-        , cl_active_cancel_req int
-        , cl_waiting_cancel_req int
-        , sv_active int
-        , sv_active_cancel int
-        , sv_being_canceled int
-        , sv_idle int
-        , sv_used int
-        , sv_tested int
-        , sv_login int
-        , maxwait int
-        , maxwait_us int
-        , pool_mode text
-    );
+    SELECT pgbouncer_target_host 
+        , database
+        , "user"
+        , cl_active
+        , cl_waiting
+        , cl_active_cancel_req
+        , cl_waiting_cancel_req
+        , sv_active
+        , sv_active_cancel
+        , sv_being_canceled
+        , sv_idle
+        , sv_used
+        , sv_tested
+        , sv_login
+        , maxwait
+        , maxwait_us
+        , pool_mode
+    FROM @extschema@.pgbouncer_pools_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_servers AS
-    SELECT type
-           , "user"
-           , database
-           , state
-           , addr
-           , port
-           , local_addr
-           , local_port
-           , connect_time
-           , request_time
-           , wait
-           , wait_us
-           , close_needed
-           , ptr
-           , link
-           , remote_pid
-           , tls
-           , application_name
-    FROM dblink('pgbouncer', 'show servers') AS x
-    (   type text
-        , "user" text
-        , database text
-        , state text
-        , addr text
-        , port int
-        , local_addr text
-        , local_port int
-        , connect_time timestamp with time zone
-        , request_time timestamp with time zone
-        , wait int
-        , wait_us int
-        , close_needed int
-        , ptr text
-        , link text
-        , remote_pid int
-        , tls text
-        , application_name text
-    );
+    SELECT pgbouncer_target_host
+        "type"
+        , "user"
+        , database
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+     FROM @extschema@.pgbouncer_servers_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_sockets AS
-    SELECT type
-           , "user"
-           , database
-           , state
-           , addr
-           , port
-           , local_addr
-           , local_port
-           , connect_time
-           , request_time
-           , wait
-           , wait_us
-           , close_needed
-           , ptr
-           , link
-           , remote_pid
-           , tls
-           , application_name
-           , recv_pos
-           , pkt_pos
-           , pkt_remain
-           , send_pos
-           , send_remain
-           , pkt_avail
-           , send_avail
-    FROM dblink('pgbouncer', 'show sockets') AS x
-    (   type text
-        , "user" text
-        , database text
-        , state text
-        , addr text
-        , port int
-        , local_addr text
-        , local_port int
-        , connect_time timestamp with time zone
-        , request_time timestamp with time zone
-        , wait int
-        , wait_us int
-        , close_needed int
-        , ptr text
-        , link text
-        , remote_pid int
-        , tls text
-        , application_name text
-        , recv_pos int
-        , pkt_pos int
-        , pkt_remain int
-        , send_pos int
-        , send_remain int
-        , pkt_avail int
-        , send_avail int
-    );
+    SELECT pgbouncer_target_host
+        , "type"
+        , "user"
+        , database
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+        , recv_pos
+        , pkt_pos
+        , pkt_remain
+        , send_pos
+        , send_remain
+        , pkt_avail
+        , send_avail
+     FROM @extschema@.pgbouncer_sockets_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_stats AS
-    SELECT database
-           , total_xact_count
-           , total_query_count
-           , total_received
-           , total_sent
-           , total_xact_time
-           , total_query_time
-           , total_wait_time
-           , avg_xact_count
-           , avg_query_count
-           , avg_recv
-           , avg_sent
-           , avg_xact_time
-           , avg_query_time
-           , avg_wait_time
-    FROM dblink('pgbouncer', 'show stats') AS x
-    (   database text
-        , total_xact_count bigint
-        , total_query_count bigint
-        , total_received bigint
-        , total_sent bigint
-        , total_xact_time bigint
-        , total_query_time bigint
-        , total_wait_time bigint
-        , avg_xact_count bigint
-        , avg_query_count bigint
-        , avg_recv bigint
-        , avg_sent bigint
-        , avg_xact_time bigint
-        , avg_query_time bigint
-        , avg_wait_time bigint
-    );
+    SELECT pgbouncer_target_host
+        , database
+        , total_xact_count
+        , total_query_count
+        , total_received
+        , total_sent
+        , total_xact_time
+        , total_query_time
+        , total_wait_time
+        , avg_xact_count
+        , avg_query_count
+        , avg_recv
+        , avg_sent
+        , avg_xact_time
+        , avg_query_time
+        , avg_wait_time
+     FROM @extschema@.pgbouncer_stats_func();
 
 
 CREATE VIEW @extschema@.pgbouncer_users AS
-    SELECT name
-           , pool_mode
-    FROM dblink('pgbouncer', 'show users') AS x
-    (   name text
-        , pool_mode text
-    );
+    SELECT pgbouncer_target_host
+        , name
+        , pool_mode
+     FROM @extschema@.pgbouncer_users_func();
+
+

--- a/sql/views/pgbouncer_fdw_views.sql
+++ b/sql/views/pgbouncer_fdw_views.sql
@@ -1,5 +1,6 @@
 CREATE VIEW @extschema@.pgbouncer_version AS
-    SELECT version_major
+    SELECT pgbouncer_target_host
+        ,  version_major
         , version_minor
         , version_patch
     FROM @extschema@.pgbouncer_version_func();

--- a/sql/views/pgbouncer_fdw_views.sql
+++ b/sql/views/pgbouncer_fdw_views.sql
@@ -73,8 +73,8 @@ CREATE VIEW @extschema@.pgbouncer_dns_zones AS
 
 CREATE VIEW @extschema@.pgbouncer_lists AS
     SELECT pgbouncer_target_host
-        , list text
-        , items int
+        , list
+        , items
      FROM @extschema@.pgbouncer_lists_func();
 
 

--- a/updates/pgbouncer_fdw--0.5--1.0.0.sql
+++ b/updates/pgbouncer_fdw--0.5--1.0.0.sql
@@ -1,0 +1,403 @@
+-- Allow gathering statistics from multiple pgbouncer targets
+    -- TODO see if exception can be caught when target it unconnectable to allow stats for working hosts
+
+
+CREATE TEMP TABLE pgbouncer_fdw_preserve_privs_temp (statement text);
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_clients TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_clients'
+GROUP BY grantee;
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_pools; TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_pools;'
+GROUP BY grantee;
+
+
+DROP VIEW @extschema@.pgbouncer_clients;
+DROP VIEW @extschema@.pgbouncer_pools;
+
+CREATE TABLE @extschema@.pgbouncer_fdw_targets (
+    target_host text NOT NULL
+    , active boolean NOT NULL DEFAULT true
+    , CONSTRAINT pgbouncer_fdw_targets_pk PRIMARY KEY (target_host) );
+
+INSERT INTO @extschema@.pgbouncer_fdw_targets ( target_host ) VALUES ('pgbouncer');
+
+CREATE FUNCTION  @extschema@.pgbouncer_version_func(p_target_host text DEFAULT NULL) RETURNS TABLE
+(
+    pgbouncer_target_host text
+    , version_major int
+    , version_minor int
+    , version_patch int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_row   record;
+    v_sql   text;
+BEGIN
+
+v_sql := 'SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active';
+IF p_target_host IS NOT NULL THEN
+    v_sql := v_sql || format(' AND target_host = %L', p_target_host);
+END IF;
+
+FOR v_row IN EXECUTE v_sql
+LOOP
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , split_part(substring(version from '\d.+'), '.', 1)::int AS version_major
+        , split_part(substring(version from '\d.+'), '.', 2)::int AS version_minor
+        , split_part(substring(version from '\d.+'), '.', 3)::int AS version_patch
+    FROM dblink(v_row.target_host, 'show version') AS x
+    (   
+        version text
+    );
+END LOOP;
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_version AS
+    SELECT version_major
+            , version_minor
+            , version_patch
+    FROM @extschema@.pgbouncer_version_func();
+
+
+CREATE FUNCTION @extschema@.pgbouncer_clients_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , "type" text
+    , "user" text
+    , database text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+           v_row.target_host AS pgbouncer_target_host
+           , x."type"
+           , x."user"
+           , x.database
+           , x.state
+           , x.addr
+           , x.port
+           , x.local_addr
+           , x.local_port
+           , x.connect_time
+           , x.request_time
+           , x.wait
+           , x.wait_us
+           , x.close_needed
+           , x.ptr
+           , x.link
+           , x.remote_pid
+           , x.tls
+           , x.application_name
+        FROM dblink(v_row.target_host, 'show clients') AS x
+        (  "type" text
+           , "user" text
+           , database text
+           , state text
+           , addr text
+           , port int
+           , local_addr text
+           , local_port int
+           , connect_time timestamp with time zone
+           , request_time timestamp with time zone
+           , wait int
+           , wait_us int
+           , close_needed int
+           , ptr text
+           , link text
+           , remote_pid int
+           , tls text
+           , application_name text
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+        RETURN QUERY SELECT 
+           v_row.target_host AS pgbouncer_target_host
+           , x."type"
+           , x."user"
+           , x.database
+           , x.state
+           , x.addr
+           , x.port
+           , x.local_addr
+           , x.local_port
+           , x.connect_time
+           , x.request_time
+           , x.wait
+           , x.wait_us
+           , x.close_needed
+           , x.ptr
+           , x.link
+           , x.remote_pid
+           , x.tls
+           , '' AS application_name
+        FROM dblink(v_row.target_host, 'show clients') AS x
+        (  "type" text
+           , "user" text
+           , database text
+           , state text
+           , addr text
+           , port int
+           , local_addr text
+           , local_port int
+           , connect_time timestamp with time zone
+           , request_time timestamp with time zone
+           , wait int
+           , wait_us int
+           , close_needed int
+           , ptr text
+           , link text
+           , remote_pid int
+           , tls text
+        );
+    END IF;
+
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_clients AS
+    SELECT type
+           , "user"
+           , database
+           , state
+           , addr
+           , port
+           , local_addr
+           , local_port
+           , connect_time
+           , request_time
+           , wait
+           , wait_us
+           , close_needed
+           , ptr
+           , link
+           , remote_pid
+           , tls
+           , application_name
+    FROM @extschema@.pgbouncer_clients_func();
+
+
+CREATE FUNCTION @extschema@.pgbouncer_pools_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , database text
+    , "user" text
+    , cl_active int
+    , cl_waiting int
+    , cl_active_cancel_req int
+    , cl_waiting_cancel_req int
+    , sv_active int
+    , sv_active_cancel int
+    , sv_being_canceled int
+    , sv_idle int
+    , sv_used int
+    , sv_tested int
+    , sv_login int
+    , maxwait int
+    , maxwait_us int
+    , pool_mode text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_row       record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+               v_row.target_host AS pgbouncer_target_host
+               , x.database
+               , x."user"
+               , x.cl_active
+               , x.cl_waiting
+               , x.cl_active_cancel_req
+               , x.cl_waiting_cancel_req
+               , x.sv_active
+               , x.sv_active_cancel
+               , x.sv_being_canceled
+               , x.sv_idle
+               , x.sv_used
+               , x.sv_tested
+               , x.sv_login
+               , x.maxwait
+               , x.maxwait_us
+               , x.pool_mode
+        FROM dblink(v_row.target_host, 'show pools') AS x
+        (   database text
+            , "user" text
+            , cl_active int
+            , cl_waiting int
+            , cl_active_cancel_req int
+            , cl_waiting_cancel_req int
+            , sv_active int
+            , sv_active_cancel int
+            , sv_being_canceled int
+            , sv_idle int
+            , sv_used int
+            , sv_tested int
+            , sv_login int
+            , maxwait int
+            , maxwait_us int
+            , pool_mode text
+        );
+    -- backward compatiblity floor is 1.17
+    -- old cl_cancel_req is sent as cl_active_cancel_req
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+
+        RETURN QUERY SELECT 
+               v_row.target_host AS pgbouncer_target_host
+               , x.database
+               , x."user"
+               , x.cl_active
+               , x.cl_waiting
+               , x.cl_cancel_req AS cl_active_cancel_req
+               , 0 AS cl_waiting_cancel_req
+               , x.sv_active
+               , 0 AS sv_active_cancel
+               , 0 AS sv_being_canceled
+               , x.sv_idle
+               , x.sv_used
+               , x.sv_tested
+               , x.sv_login
+               , x.maxwait
+               , x.maxwait_us
+               , x.pool_mode
+        FROM dblink(v_row.target_host, 'show pools') AS x
+        (   database text
+            , "user" text
+            , cl_active int
+            , cl_waiting int
+            , cl_cancel_req int
+            , sv_active int
+            , sv_idle int
+            , sv_used int
+            , sv_tested int
+            , sv_login int
+            , maxwait int
+            , maxwait_us int
+            , pool_mode text
+        );
+    END IF;
+
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_pools AS
+    SELECT database
+           , "user"
+           , cl_active
+           , cl_waiting
+           , cl_active_cancel_req
+           , cl_waiting_cancel_req
+           , sv_active
+           , sv_active_cancel
+           , sv_being_canceled
+           , sv_idle
+           , sv_used
+           , sv_tested
+           , sv_login
+           , maxwait
+           , maxwait_us
+           , pool_mode
+    FROM @extschema@.pgbouncer_pools_func();
+
+/*
+ * FUNCTION TEMPLATE 
+ *
+CREATE FUNCTION @extschema@.() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP
+
+    RETURN QUERY SELECT 
+           v_row.target_host AS pgbouncer_target_host
+    FROM dblink(v_row.target_host, '') AS x
+    (   
+
+    );
+
+END LOOP;
+
+END
+$$;
+****/
+
+
+-- Restore dropped object privileges
+DO $$
+DECLARE
+v_row   record;
+BEGIN
+    FOR v_row IN SELECT statement FROM pgbouncer_fdw_preserve_privs_temp LOOP
+        IF v_row.statement IS NOT NULL THEN
+            EXECUTE v_row.statement;
+        END IF;
+    END LOOP;
+END
+$$;
+
+DROP TABLE IF EXISTS pgbouncer_fdw_preserve_privs_temp;
+

--- a/updates/pgbouncer_fdw--0.5--1.0.0.sql
+++ b/updates/pgbouncer_fdw--0.5--1.0.0.sql
@@ -579,7 +579,7 @@ BEGIN
 
 FOR v_row IN  
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN;
+LOOP BEGIN
 
     RETURN QUERY SELECT 
         v_row.target_host AS pgbouncer_target_host
@@ -610,8 +610,8 @@ $$;
 
 CREATE VIEW @extschema@.pgbouncer_lists AS
     SELECT pgbouncer_target_host
-        , list text
-        , items int
+        , list
+        , items
      FROM @extschema@.pgbouncer_lists_func();
 
 

--- a/updates/pgbouncer_fdw--0.5--1.0.0.sql
+++ b/updates/pgbouncer_fdw--0.5--1.0.0.sql
@@ -231,6 +231,8 @@ LOOP BEGIN
            , remote_pid int
            , tls text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN
@@ -732,6 +734,8 @@ LOOP BEGIN
             , maxwait_us int
             , pool_mode text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN
@@ -901,6 +905,8 @@ LOOP BEGIN
             , remote_pid int
             , tls text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN
@@ -1106,6 +1112,8 @@ LOOP BEGIN
             , pkt_avail int
             , send_avail int
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
     END IF;
     EXCEPTION
         WHEN connection_exception THEN

--- a/updates/pgbouncer_fdw--0.5--1.0.0.sql
+++ b/updates/pgbouncer_fdw--0.5--1.0.0.sql
@@ -1,34 +1,51 @@
--- Allow gathering statistics from multiple pgbouncer targets
-    -- TODO see if exception can be caught when target it unconnectable to allow stats for working hosts
+-- IMPORTANT NOTE: All objects in this extension are dropped and recreated as part of this update. Privileges ARE NOT preserved as part of this update, so please ensure privileges you have on these objects are preserved before upgrading so that they can be reapplied. Note that execution by PUBLIC on the admin functions is once again revoked by this update.
 
+-- Add support for gathering statistics from multiple pgBouncer targets
+  -- A new configuration table has been added to define the names of all FDW servers.
+  -- All administrative command functions have had a parameter for the FDW server name added to them. These functions intentionally do not use the configuration table to avoid accidentally running an admin command on multiple servers.
 
-CREATE TEMP TABLE pgbouncer_fdw_preserve_privs_temp (statement text);
-
-INSERT INTO pgbouncer_fdw_preserve_privs_temp
-SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_clients TO '||grantee::text||';'
-FROM information_schema.table_privileges
-WHERE table_schema = '@extschema@'
-AND table_name = 'pgbouncer_clients'
-GROUP BY grantee;
-
-INSERT INTO pgbouncer_fdw_preserve_privs_temp
-SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_pools; TO '||grantee::text||';'
-FROM information_schema.table_privileges
-WHERE table_schema = '@extschema@'
-AND table_name = 'pgbouncer_pools;'
-GROUP BY grantee;
-
+-- Add better support for multiple versions of pgBouncer. Support for 1.17 has been backported into this version of pgbouncer_fdw.
 
 DROP VIEW @extschema@.pgbouncer_clients;
+DROP VIEW @extschema@.pgbouncer_config;
+DROP VIEW @extschema@.pgbouncer_databases;
+DROP VIEW @extschema@.pgbouncer_dns_hosts;
+DROP VIEW @extschema@.pgbouncer_dns_zones;
+DROP VIEW @extschema@.pgbouncer_lists;
 DROP VIEW @extschema@.pgbouncer_pools;
+DROP VIEW @extschema@.pgbouncer_servers;
+DROP VIEW @extschema@.pgbouncer_sockets;
+DROP VIEW @extschema@.pgbouncer_stats;
+DROP VIEW @extschema@.pgbouncer_users;
 
+DROP FUNCTION @extschema@.pgbouncer_command_disable(text);
+DROP FUNCTION @extschema@.pgbouncer_command_enable(text);
+DROP FUNCTION @extschema@.pgbouncer_command_kill(text);
+DROP FUNCTION @extschema@.pgbouncer_command_pause(text);
+DROP FUNCTION @extschema@.pgbouncer_command_reconnect(text);
+DROP FUNCTION @extschema@.pgbouncer_command_reload();
+DROP FUNCTION @extschema@.pgbouncer_command_resume(text);
+DROP FUNCTION @extschema@.pgbouncer_command_set(text, text);
+DROP FUNCTION @extschema@.pgbouncer_command_shutdown();
+DROP FUNCTION @extschema@.pgbouncer_command_suspend();
+DROP FUNCTION @extschema@.pgbouncer_command_wait_close(text);
+
+/*
+ * pgbouncer_fdw_targets 
+ */
 CREATE TABLE @extschema@.pgbouncer_fdw_targets (
     target_host text NOT NULL
     , active boolean NOT NULL DEFAULT true
     , CONSTRAINT pgbouncer_fdw_targets_pk PRIMARY KEY (target_host) );
+CREATE INDEX pgbouncer_fdw_targets_active_idx ON pgbouncer_fdw_targets (active);
+SELECT pg_catalog.pg_extension_config_dump('pgbouncer_fdw_targets', '');
 
 INSERT INTO @extschema@.pgbouncer_fdw_targets ( target_host ) VALUES ('pgbouncer');
 
+
+/*
+ * pgbouncer_version_func
+ */
 CREATE FUNCTION  @extschema@.pgbouncer_version_func(p_target_host text DEFAULT NULL) RETURNS TABLE
 (
     pgbouncer_target_host text
@@ -39,6 +56,10 @@ CREATE FUNCTION  @extschema@.pgbouncer_version_func(p_target_host text DEFAULT N
 LANGUAGE plpgsql
 AS $$
 DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
     v_row   record;
     v_sql   text;
 BEGIN
@@ -49,7 +70,7 @@ IF p_target_host IS NOT NULL THEN
 END IF;
 
 FOR v_row IN EXECUTE v_sql
-LOOP
+LOOP BEGIN
     RETURN QUERY SELECT 
         v_row.target_host AS pgbouncer_target_host
         , split_part(substring(version from '\d.+'), '.', 1)::int AS version_major
@@ -59,17 +80,32 @@ LOOP
     (   
         version text
     );
+    EXCEPTION
+        WHEN connection_exception THEN
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
 END LOOP;
 END
 $$;
 
 CREATE VIEW @extschema@.pgbouncer_version AS
     SELECT version_major
-            , version_minor
-            , version_patch
+        , version_minor
+        , version_patch
     FROM @extschema@.pgbouncer_version_func();
 
 
+/*
+ * pgbouncer_clients_func
+ */
 CREATE FUNCTION @extschema@.pgbouncer_clients_func() RETURNS TABLE 
 ( 
     pgbouncer_target_host text
@@ -95,6 +131,10 @@ CREATE FUNCTION @extschema@.pgbouncer_clients_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
     v_row               record;
     v_version_major     int;
     v_version_minor     int;
@@ -102,7 +142,7 @@ BEGIN
 
 FOR v_row IN  
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP
+LOOP BEGIN
 
     SELECT version_major, version_minor
     INTO v_version_major, v_version_minor
@@ -191,34 +231,393 @@ LOOP
            , tls text
         );
     END IF;
-
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
 END LOOP;
 
 END
 $$;
 
 CREATE VIEW @extschema@.pgbouncer_clients AS
-    SELECT type
-           , "user"
-           , database
-           , state
-           , addr
-           , port
-           , local_addr
-           , local_port
-           , connect_time
-           , request_time
-           , wait
-           , wait_us
-           , close_needed
-           , ptr
-           , link
-           , remote_pid
-           , tls
-           , application_name
+    SELECT pgbouncer_target_host
+        , "type"
+        , "user"
+        , database
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
     FROM @extschema@.pgbouncer_clients_func();
 
 
+/*
+ * pgbouncer_config_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_config_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , key text
+    , value text
+    , "default" text
+    , changeable boolean
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.key
+        , x.value
+        , x."default"
+        , x.changeable
+    FROM dblink(v_row.target_host, 'show config') AS x
+    (   key text
+        , value text
+        , "default" text
+        , changeable boolean
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_config AS
+    SELECT pgbouncer_target_host
+        , key
+        , value
+        , "default"
+        , changeable
+    FROM @extschema@.pgbouncer_config_func();
+
+
+/*
+ * pgbouncer_databases_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , name text
+    , host text
+    , port int
+    , database text
+    , force_user text
+    , pool_size int
+    , min_pool_size int
+    , reserve_pool int
+    , pool_mode text
+    , max_connections int
+    , current_connections int
+    , paused int
+    , disabled int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.name
+        , x.host
+        , x.port
+        , x.database
+        , x.force_user
+        , x.pool_size
+        , x.min_pool_size
+        , x.reserve_pool
+        , x.pool_mode
+        , x.max_connections
+        , x.current_connections
+        , x.paused
+        , x.disabled
+    FROM dblink(v_row.target_host, 'show databases') AS x
+    (   
+        name text
+        , host text
+        , port int
+        , database text
+        , force_user text
+        , pool_size int
+        , min_pool_size int
+        , reserve_pool int
+        , pool_mode text
+        , max_connections int
+        , current_connections int
+        , paused int
+        , disabled int
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_databases AS
+    SELECT pgbouncer_target_host
+        , name
+        , host
+        , port
+        , database
+        , force_user
+        , pool_size
+        , min_pool_size
+        , reserve_pool
+        , pool_mode
+        , max_connections
+        , current_connections
+        , paused
+        , disabled
+     FROM @extschema@.pgbouncer_databases_func();
+
+
+/*
+ * pgbouncer_dns_hosts_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_dns_hosts_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , hostname text
+    , ttl bigint
+    , addrs text
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.hostname
+        , x.ttl
+        , x.addrs
+    FROM dblink(v_row.target_host, 'show dns_hosts') AS x
+    (   
+        hostname text
+        , ttl bigint
+        , addrs text
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_dns_hosts AS
+    SELECT pgbouncer_target_host
+        , hostname
+        , ttl
+        , addrs
+     FROM @extschema@.pgbouncer_dns_hosts_func();
+
+/*
+ * pgbouncer_dns_zones_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_dns_zones_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , zonename text
+    , serial text
+    , count int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.zonename
+        , x.serial
+        , x.count
+    FROM dblink(v_row.target_host, 'show dns_zones') AS x
+    (   
+        zonename text
+        , serial text
+        , count int
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_dns_zones AS
+    SELECT pgbouncer_target_host
+        zonename
+        , serial
+        , count
+     FROM @extschema@.pgbouncer_dns_zones_func();
+
+
+/*
+ * pgbouncer_lists_func
+ */ 
+CREATE FUNCTION @extschema@.pgbouncer_lists_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , list text
+    , items int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN;
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.list
+        , x.items
+    FROM dblink(v_row.target_host, 'show lists') AS x
+    (   
+        list text
+        , items int
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_lists AS
+    SELECT pgbouncer_target_host
+        , list text
+        , items int
+     FROM @extschema@.pgbouncer_lists_func();
+
+
+/*
+ * pgbouncer_pools_func
+ */
 CREATE FUNCTION @extschema@.pgbouncer_pools_func() RETURNS TABLE 
 ( 
     pgbouncer_target_host text
@@ -242,6 +641,10 @@ CREATE FUNCTION @extschema@.pgbouncer_pools_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
     v_row       record;
     v_version_major     int;
     v_version_minor     int;
@@ -249,7 +652,7 @@ BEGIN
 
 FOR v_row IN  
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP
+LOOP BEGIN
 
     SELECT version_major, version_minor
     INTO v_version_major, v_version_minor
@@ -293,17 +696,16 @@ LOOP
             , pool_mode text
         );
     -- backward compatiblity floor is 1.17
-    -- old cl_cancel_req is sent as cl_active_cancel_req
+    -- old cl_cancel_req is sent as cl_waiting_cancel_req
     ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
-
         RETURN QUERY SELECT 
                v_row.target_host AS pgbouncer_target_host
                , x.database
                , x."user"
                , x.cl_active
                , x.cl_waiting
-               , x.cl_cancel_req AS cl_active_cancel_req
-               , 0 AS cl_waiting_cancel_req
+               , 0 AS cl_active_cancel_req
+               , x.cl_cancel_req AS cl_waiting_cancel_req
                , x.sv_active
                , 0 AS sv_active_cancel
                , 0 AS sv_being_canceled
@@ -330,74 +732,711 @@ LOOP
             , pool_mode text
         );
     END IF;
-
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
 END LOOP;
 
 END
 $$;
 
 CREATE VIEW @extschema@.pgbouncer_pools AS
-    SELECT database
-           , "user"
-           , cl_active
-           , cl_waiting
-           , cl_active_cancel_req
-           , cl_waiting_cancel_req
-           , sv_active
-           , sv_active_cancel
-           , sv_being_canceled
-           , sv_idle
-           , sv_used
-           , sv_tested
-           , sv_login
-           , maxwait
-           , maxwait_us
-           , pool_mode
+    SELECT pgbouncer_target_host 
+        , database
+        , "user"
+        , cl_active
+        , cl_waiting
+        , cl_active_cancel_req
+        , cl_waiting_cancel_req
+        , sv_active
+        , sv_active_cancel
+        , sv_being_canceled
+        , sv_idle
+        , sv_used
+        , sv_tested
+        , sv_login
+        , maxwait
+        , maxwait_us
+        , pool_mode
     FROM @extschema@.pgbouncer_pools_func();
 
+
 /*
- * FUNCTION TEMPLATE 
- *
-CREATE FUNCTION @extschema@.() RETURNS TABLE 
+ * pgbouncer_servers_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_servers_func() RETURNS TABLE 
 ( 
     pgbouncer_target_host text
+    , "type" text
+    , "user" text
+    , database text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
 )
 LANGUAGE plpgsql
 AS $$
 DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , '' AS application_name
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+        );
+    END IF;
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_servers AS
+    SELECT pgbouncer_target_host
+        "type"
+        , "user"
+        , database
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+     FROM @extschema@.pgbouncer_servers_func();
+
+
+/*
+ * pgbouncer_sockets_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_sockets_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , "type" text
+    , "user" text
+    , database text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
+    , recv_pos int
+    , pkt_pos int
+    , pkt_remain int
+    , send_pos int
+    , send_remain int
+    , pkt_avail int
+    , send_avail int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+  
+    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
+        RETURN QUERY SELECT 
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , '' AS application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (   
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+        );
+    END IF;
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+CREATE VIEW @extschema@.pgbouncer_sockets AS
+    SELECT pgbouncer_target_host
+        , "type"
+        , "user"
+        , database
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+        , recv_pos
+        , pkt_pos
+        , pkt_remain
+        , send_pos
+        , send_remain
+        , pkt_avail
+        , send_avail
+     FROM @extschema@.pgbouncer_sockets_func();
+
+
+/*
+ * pgbouncer_stats_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , database text
+    , total_xact_count bigint
+    , total_query_count bigint
+    , total_received bigint
+    , total_sent bigint
+    , total_xact_time bigint
+    , total_query_time bigint
+    , total_wait_time bigint
+    , avg_xact_count bigint
+    , avg_query_count bigint
+    , avg_recv bigint
+    , avg_sent bigint
+    , avg_xact_time bigint
+    , avg_query_time bigint
+    , avg_wait_time bigint
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
     v_row       record;
 BEGIN
 
 FOR v_row IN  
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP
+LOOP BEGIN
 
     RETURN QUERY SELECT 
-           v_row.target_host AS pgbouncer_target_host
-    FROM dblink(v_row.target_host, '') AS x
+        v_row.target_host AS pgbouncer_target_host
+        , x.database
+        , x.total_xact_count
+        , x.total_query_count
+        , x.total_received
+        , x.total_sent
+        , x.total_xact_time
+        , x.total_query_time
+        , x.total_wait_time
+        , x.avg_xact_count
+        , x.avg_query_count
+        , x.avg_recv
+        , x.avg_sent
+        , x.avg_xact_time
+        , x.avg_query_time
+        , x.avg_wait_time
+    FROM dblink(v_row.target_host, 'show stats') AS x
     (   
-
+        database text
+        , total_xact_count bigint
+        , total_query_count bigint
+        , total_received bigint
+        , total_sent bigint
+        , total_xact_time bigint
+        , total_query_time bigint
+        , total_wait_time bigint
+        , avg_xact_count bigint
+        , avg_query_count bigint
+        , avg_recv bigint
+        , avg_sent bigint
+        , avg_xact_time bigint
+        , avg_query_time bigint
+        , avg_wait_time bigint
     );
-
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
 END LOOP;
 
 END
 $$;
-****/
 
+CREATE VIEW @extschema@.pgbouncer_stats AS
+    SELECT pgbouncer_target_host
+        , database
+        , total_xact_count
+        , total_query_count
+        , total_received
+        , total_sent
+        , total_xact_time
+        , total_query_time
+        , total_wait_time
+        , avg_xact_count
+        , avg_query_count
+        , avg_recv
+        , avg_sent
+        , avg_xact_time
+        , avg_query_time
+        , avg_wait_time
+     FROM @extschema@.pgbouncer_stats_func();
 
--- Restore dropped object privileges
-DO $$
+/*
+ * pgbouncer_users_func
+ */
+CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE 
+( 
+    pgbouncer_target_host text
+    , name text
+    , pool_mode text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
-v_row   record;
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row       record;
 BEGIN
-    FOR v_row IN SELECT statement FROM pgbouncer_fdw_preserve_privs_temp LOOP
-        IF v_row.statement IS NOT NULL THEN
-            EXECUTE v_row.statement;
-        END IF;
-    END LOOP;
+
+FOR v_row IN  
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+
+    RETURN QUERY SELECT 
+        v_row.target_host AS pgbouncer_target_host
+        , x.name
+        , x.pool_mode
+    FROM dblink(v_row.target_host, 'show users') AS x
+    (   
+        name text
+        , pool_mode text
+    );
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
 END
 $$;
 
-DROP TABLE IF EXISTS pgbouncer_fdw_preserve_privs_temp;
+CREATE VIEW @extschema@.pgbouncer_users AS
+    SELECT pgbouncer_target_host
+        , name
+        , pool_mode
+     FROM @extschema@.pgbouncer_users_func();
+
+
+/**** ADMIN FUNCTIONS */
+
+CREATE FUNCTION @extschema@.pgbouncer_command_disable(p_dbname text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, format('DISABLE %I', p_dbname));
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_enable(p_dbname text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, format('ENABLE %I', p_dbname));
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_kill(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF p_dbname IS NULL THEN
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'KILL');
+    ELSE
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('KILL %I', p_dbname));
+    END IF;
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_pause(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF p_dbname IS NULL THEN
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'PAUSE');
+    ELSE
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('PAUSE %I', p_dbname));
+    END IF;
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_reconnect(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF p_dbname IS NULL THEN
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'RECONNECT');
+    ELSE
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('RECONNECT %I', p_dbname));
+    END IF;
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_reload(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, 'RELOAD');
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_resume(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF p_dbname IS NULL THEN
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'RESUME');
+    ELSE
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('RESUME %I', p_dbname));
+    END IF;
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_set(p_name text, p_value text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, format('SET %s = %L', p_name, p_value));
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_shutdown(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, 'shutdown');
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_suspend(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM dblink_exec(p_pgbouncer_target_host, 'SUSPEND');
+END
+$$;
+
+CREATE FUNCTION @extschema@.pgbouncer_command_wait_close(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF p_dbname IS NULL THEN
+        PERFORM dblink_exec(p_pgbouncer_target_host, 'WAIT_CLOSE');
+    ELSE
+        PERFORM dblink_exec(p_pgbouncer_target_host, format('WAIT_CLOSE %I', p_dbname));
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_disable(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_enable(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_kill(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_pause(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reconnect(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reload(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_resume(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_set(text, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_shutdown(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_suspend(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_wait_close(text, text) FROM PUBLIC;
 

--- a/updates/pgbouncer_fdw--0.5--1.0.0.sql
+++ b/updates/pgbouncer_fdw--0.5--1.0.0.sql
@@ -97,7 +97,8 @@ END
 $$;
 
 CREATE VIEW @extschema@.pgbouncer_version AS
-    SELECT version_major
+    SELECT pgbouncer_target_host
+        , version_major
         , version_minor
         , version_patch
     FROM @extschema@.pgbouncer_version_func();


### PR DESCRIPTION
Allow support for monitoring multiple pgBouncer targets. Adds a column to the returned rows that identifies the FDW server name. 

Switching to underlying functions also allows for support of multiple versions of pgBouncer when the columns returned by the SHOW commands change. Retroactively adds support for pgBouncer v1.17 to ensure multi-version support is working.