### PR TITLE
Add support for pgbouncer 1.23

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v1.2.0
+-- Add support for PgBouncer 1.23.
+  -- Adds replication column to clients, servers and sockets functions and views.
+  -- Adds server_lifetime column to databases functions and views.
+  -- Adds total_server_assignment_count and avg_server_assignment_count columns to stats functions and views.
+  -- Adds pool_size, max_user_connections and current_connections columns to users functions and views.
+
+
 v1.1.0
 -- Add support for PgBouncer 1.21. Adds prepared_statements column to clients, servers and sockets functions and views.
 

--- a/pgbouncer_fdw.control
+++ b/pgbouncer_fdw.control
@@ -1,4 +1,4 @@
-default_version = '1.1.0'
+default_version = '1.2.0'
 comment = 'Extension for querying PgBouncer stats from normal SQL views & running pgbouncer commands from normal SQL functions'
 requires = dblink
 relocatable = false

--- a/sql/functions/pgbouncer_fdw_functions.sql
+++ b/sql/functions/pgbouncer_fdw_functions.sql
@@ -358,8 +358,8 @@ $$;
 /*
  * pgbouncer_databases_func
  */
-CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE 
-( 
+CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE
+(
     pgbouncer_target_host text
     , name text
     , host text
@@ -379,16 +379,22 @@ CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
+    ex_context          text;
+    ex_detail           text;
+    ex_hint             text;
+    ex_message          text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
 
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
         RETURN QUERY SELECT
@@ -457,6 +463,9 @@ LOOP BEGIN
             , paused int
             , disabled int
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
     EXCEPTION
         WHEN connection_exception THEN
             RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
@@ -1334,8 +1343,8 @@ $$;
 /*
  * pgbouncer_stats_func
  */
-CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE 
-( 
+CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE
+(
     pgbouncer_target_host text
     , database text
     , total_server_assignment_count bigint
@@ -1358,16 +1367,22 @@ CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
+    ex_context          text;
+    ex_detail           text;
+    ex_hint             text;
+    ex_message          text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
 
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
         RETURN QUERY SELECT
@@ -1447,6 +1462,9 @@ LOOP BEGIN
             , avg_query_time bigint
             , avg_wait_time bigint
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
     EXCEPTION
         WHEN connection_exception THEN
             RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
@@ -1465,11 +1483,12 @@ END LOOP;
 END
 $$;
 
+
 /*
  * pgbouncer_users_func
  */
-CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE 
-( 
+CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE
+(
     pgbouncer_target_host text
     , name text
     , pool_size text
@@ -1480,16 +1499,23 @@ CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
+    ex_context          text;
+    ex_detail           text;
+    ex_hint             text;
+    ex_message          text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
         RETURN QUERY SELECT
             v_row.target_host AS pgbouncer_target_host
@@ -1519,6 +1545,9 @@ LOOP BEGIN
             name text
             , pool_mode text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
     EXCEPTION
         WHEN connection_exception THEN
             RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;

--- a/sql/views/pgbouncer_fdw_views.sql
+++ b/sql/views/pgbouncer_fdw_views.sql
@@ -11,6 +11,7 @@ CREATE VIEW @extschema@.pgbouncer_clients AS
         , "type"
         , "user"
         , database
+        , replication
         , state
         , addr
         , port
@@ -49,6 +50,7 @@ CREATE VIEW @extschema@.pgbouncer_databases AS
         , pool_size
         , min_pool_size
         , reserve_pool
+        , server_lifetime
         , pool_mode
         , max_connections
         , current_connections
@@ -106,6 +108,7 @@ CREATE VIEW @extschema@.pgbouncer_servers AS
         , "type"
         , "user"
         , database
+        , replication
         , state
         , addr
         , port
@@ -130,6 +133,7 @@ CREATE VIEW @extschema@.pgbouncer_sockets AS
         , "type"
         , "user"
         , database
+        , replication
         , state
         , addr
         , port
@@ -159,6 +163,7 @@ CREATE VIEW @extschema@.pgbouncer_sockets AS
 CREATE VIEW @extschema@.pgbouncer_stats AS
     SELECT pgbouncer_target_host
         , database
+        , total_server_assignment_count
         , total_xact_count
         , total_query_count
         , total_received
@@ -166,6 +171,7 @@ CREATE VIEW @extschema@.pgbouncer_stats AS
         , total_xact_time
         , total_query_time
         , total_wait_time
+        , avg_server_assignment_count
         , avg_xact_count
         , avg_query_count
         , avg_recv
@@ -179,5 +185,8 @@ CREATE VIEW @extschema@.pgbouncer_stats AS
 CREATE VIEW @extschema@.pgbouncer_users AS
     SELECT pgbouncer_target_host
         , name
+        , pool_size
         , pool_mode
+        , max_user_connections
+        , current_connections
      FROM @extschema@.pgbouncer_users_func();

--- a/updates/pgbouncer_fdw--1.1.0--1.2.0.sql
+++ b/updates/pgbouncer_fdw--1.1.0--1.2.0.sql
@@ -1,64 +1,98 @@
+CREATE TEMP TABLE pgbouncer_fdw_preserve_privs_temp (statement text);
 
-/**** VIEW FUNCTIONS ****/
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_clients TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_clients'
+GROUP BY grantee;
 
-/*
- * pgbouncer_version_func
- */
-CREATE FUNCTION  @extschema@.pgbouncer_version_func(p_target_host text DEFAULT NULL) RETURNS TABLE
-(
-    pgbouncer_target_host text
-    , version_major int
-    , version_minor int
-    , version_patch int
-)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row   record;
-    v_sql   text;
-BEGIN
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_servers TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_servers'
+GROUP BY grantee;
 
-v_sql := 'SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active';
-IF p_target_host IS NOT NULL THEN
-    v_sql := v_sql || format(' AND target_host = %L', p_target_host);
-END IF;
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_sockets TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_sockets'
+GROUP BY grantee;
 
-FOR v_row IN EXECUTE v_sql
-LOOP BEGIN
-    RETURN QUERY SELECT 
-        v_row.target_host AS pgbouncer_target_host
-        , split_part(substring(version from '\d.+'), '.', 1)::int AS version_major
-        , split_part(substring(version from '\d.+'), '.', 2)::int AS version_minor
-        , split_part(substring(version from '\d.+'), '.', 3)::int AS version_patch
-    FROM dblink(v_row.target_host, 'show version') AS x
-    (   
-        version text
-    );
-    EXCEPTION
-        WHEN connection_exception THEN
-            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
-                                    ex_context = PG_EXCEPTION_CONTEXT,
-                                    ex_detail = PG_EXCEPTION_DETAIL,
-                                    ex_hint = PG_EXCEPTION_HINT;
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
-ORIGINAL ERROR: %
-CONTEXT: %
-DETAIL: %
-HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
-END;
-END LOOP;
-END
-$$;
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_databases TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_databases'
+GROUP BY grantee;
 
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_stats TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_stats'
+GROUP BY grantee;
 
-/*
- * pgbouncer_clients_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_clients_func() RETURNS TABLE 
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_users TO '||grantee::text||';'
+FROM information_schema.table_privileges
+WHERE table_schema = '@extschema@'
+AND table_name = 'pgbouncer_users'
+GROUP BY grantee;
+
+DROP VIEW @extschema@.pgbouncer_clients;
+DROP VIEW @extschema@.pgbouncer_servers;
+DROP VIEW @extschema@.pgbouncer_sockets;
+DROP VIEW @extschema@.pgbouncer_databases;
+DROP VIEW @extschema@.pgbouncer_stats;
+DROP VIEW @extschema@.pgbouncer_users;
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp 
+SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_clients_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';' 
+FROM information_schema.routine_privileges
+WHERE routine_schema = '@extschema@'
+AND routine_name = 'pgbouncer_clients_func';
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp 
+SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_servers_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';' 
+FROM information_schema.routine_privileges
+WHERE routine_schema = '@extschema@'
+AND routine_name = 'pgbouncer_servers_func';
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp 
+SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_sockets_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';' 
+FROM information_schema.routine_privileges
+WHERE routine_schema = '@extschema@'
+AND routine_name = 'pgbouncer_sockets_func';
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_databases_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';'
+FROM information_schema.routine_privileges
+WHERE routine_schema = '@extschema@'
+AND routine_name = 'pgbouncer_databases_func';
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_stats_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';'
+FROM information_schema.routine_privileges
+WHERE routine_schema = '@extschema@'
+AND routine_name = 'pgbouncer_stats_func';
+
+INSERT INTO pgbouncer_fdw_preserve_privs_temp
+SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_users_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';'
+FROM information_schema.routine_privileges
+WHERE routine_schema = '@extschema@'
+AND routine_name = 'pgbouncer_users_func';
+
+DROP FUNCTION @extschema@.pgbouncer_clients_func();
+DROP FUNCTION @extschema@.pgbouncer_servers_func();
+DROP FUNCTION @extschema@.pgbouncer_sockets_func();
+DROP FUNCTION @extschema@.pgbouncer_databases_func();
+DROP FUNCTION @extschema@.pgbouncer_stats_func();
+DROP FUNCTION @extschema@.pgbouncer_users_func();
+
+CREATE FUNCTION @extschema@.pgbouncer_clients_func() RETURNS TABLE
 ( 
     pgbouncer_target_host text
     , "type" text
@@ -94,14 +128,14 @@ DECLARE
     v_version_minor     int;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
 
     SELECT version_major, version_minor
     INTO v_version_major, v_version_minor
     FROM @extschema@.pgbouncer_version_func(v_row.target_host);
-  
+
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
         RETURN QUERY SELECT
            v_row.target_host AS pgbouncer_target_host
@@ -148,7 +182,7 @@ LOOP BEGIN
            , prepared_statements int
         );
     ELSIF v_version_major = 1 AND v_version_minor >= 21 and v_version_minor < 23 THEN
-        RETURN QUERY SELECT 
+        RETURN QUERY SELECT
            v_row.target_host AS pgbouncer_target_host
            , x."type"
            , x."user"
@@ -191,8 +225,8 @@ LOOP BEGIN
            , application_name text
            , prepared_statements int
         );
-    ELSIF v_version_major = 1 AND v_version_minor >= 18 AND v_version_minor < 21 THEN 
-        RETURN QUERY SELECT 
+    ELSIF v_version_major = 1 AND v_version_minor >= 18 AND v_version_minor < 21 THEN
+        RETURN QUERY SELECT
            v_row.target_host AS pgbouncer_target_host
            , x."type"
            , x."user"
@@ -235,8 +269,8 @@ LOOP BEGIN
            , application_name text
         );
     -- backward compatiblity floor is 1.17
-    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
-        RETURN QUERY SELECT 
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN
+        RETURN QUERY SELECT
            v_row.target_host AS pgbouncer_target_host
            , x."type"
            , x."user"
@@ -299,16 +333,29 @@ END
 $$;
 
 
-/*
- * pgbouncer_config_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_config_func() RETURNS TABLE 
-( 
+CREATE FUNCTION @extschema@.pgbouncer_servers_func() RETURNS TABLE
+(
     pgbouncer_target_host text
-    , key text
-    , value text
-    , "default" text
-    , changeable boolean
+    , "type" text
+    , "user" text
+    , database text
+    , replication text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
+    , prepared_statements int
 )
 LANGUAGE plpgsql
 AS $$
@@ -317,25 +364,201 @@ DECLARE
     ex_detail                       text;
     ex_hint                         text;
     ex_message                      text;
-    v_row       record;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
 
-    RETURN QUERY SELECT 
-        v_row.target_host AS pgbouncer_target_host
-        , x.key
-        , x.value
-        , x."default"
-        , x.changeable
-    FROM dblink(v_row.target_host, 'show config') AS x
-    (   key text
-        , value text
-        , "default" text
-        , changeable boolean
-    );
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+
+    IF v_version_major >= 1 AND v_version_minor >= 23 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , x.prepared_statements
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , replication text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+            , prepared_statements int
+        );
+    ELSIF v_version_major = 1 AND v_version_minor >= 21 and v_version_minor < 23 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , '' AS replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , x.prepared_statements
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+            , prepared_statements int
+        );
+    ELSIF v_version_major = 1 AND v_version_minor >= 18 and v_version_minor < 21 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , '' AS replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , 0 AS prepared_statements
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , '' AS replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , '' AS application_name
+            , 0 AS prepared_statements
+        FROM dblink(v_row.target_host, 'show servers') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+        );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
     EXCEPTION
         WHEN connection_exception THEN
             RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
@@ -355,11 +578,315 @@ END
 $$;
 
 
-/*
- * pgbouncer_databases_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE 
+CREATE FUNCTION @extschema@.pgbouncer_sockets_func() RETURNS TABLE 
 ( 
+    pgbouncer_target_host text
+    , "type" text
+    , "user" text
+    , database text
+    , replication text
+    , state text
+    , addr text
+    , port int
+    , local_addr text
+    , local_port int
+    , connect_time timestamp with time zone
+    , request_time timestamp with time zone
+    , wait int
+    , wait_us int
+    , close_needed int
+    , ptr text
+    , link text
+    , remote_pid int
+    , tls text
+    , application_name text
+    , recv_pos int
+    , pkt_pos int
+    , pkt_remain int
+    , send_pos int
+    , send_remain int
+    , pkt_avail int
+    , send_avail int
+    , prepared_statements int
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ex_context                      text;
+    ex_detail                       text;
+    ex_hint                         text;
+    ex_message                      text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
+BEGIN
+
+FOR v_row IN
+    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
+LOOP BEGIN
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+
+    IF v_version_major >= 1 AND v_version_minor >= 23 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , x.replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+            , x.prepared_statements
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , replication text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+            , prepared_statements int
+        );
+    ELSIF v_version_major = 1 AND v_version_minor >= 21 AND v_version_minor < 23 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , '' AS replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+            , x.prepared_statements
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+            , prepared_statements int
+        );
+    ELSIF v_version_major = 1 AND v_version_minor >= 18 AND v_version_minor < 21 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , '' AS replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , x.application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+            , 0 AS prepared_statements
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , application_name text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+        );
+    -- backward compatiblity floor is 1.17
+    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN
+        RETURN QUERY SELECT
+            v_row.target_host AS pgbouncer_target_host
+            , x."type"
+            , x."user"
+            , x.database
+            , '' AS replication
+            , x.state
+            , x.addr
+            , x.port
+            , x.local_addr
+            , x.local_port
+            , x.connect_time
+            , x.request_time
+            , x.wait
+            , x.wait_us
+            , x.close_needed
+            , x.ptr
+            , x.link
+            , x.remote_pid
+            , x.tls
+            , '' AS application_name
+            , x.recv_pos
+            , x.pkt_pos
+            , x.pkt_remain
+            , x.send_pos
+            , x.send_remain
+            , x.pkt_avail
+            , x.send_avail
+            , 0 AS prepared_statements
+        FROM dblink(v_row.target_host, 'show sockets') AS x
+        (
+            "type" text
+            , "user" text
+            , database text
+            , state text
+            , addr text
+            , port int
+            , local_addr text
+            , local_port int
+            , connect_time timestamp with time zone
+            , request_time timestamp with time zone
+            , wait int
+            , wait_us int
+            , close_needed int
+            , ptr text
+            , link text
+            , remote_pid int
+            , tls text
+            , recv_pos int
+            , pkt_pos int
+            , pkt_remain int
+            , send_pos int
+            , send_remain int
+            , pkt_avail int
+            , send_avail int
+        );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
+    EXCEPTION
+        WHEN connection_exception THEN
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
+            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                    ex_context = PG_EXCEPTION_CONTEXT,
+                                    ex_detail = PG_EXCEPTION_DETAIL,
+                                    ex_hint = PG_EXCEPTION_HINT;
+            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
+ORIGINAL ERROR: %
+CONTEXT: %
+DETAIL: %
+HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
+END;
+END LOOP;
+
+END
+$$;
+
+
+CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE
+(
     pgbouncer_target_host text
     , name text
     , host text
@@ -386,7 +913,7 @@ DECLARE
     v_row       record;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
 
@@ -476,866 +1003,8 @@ END
 $$;
 
 
-/*
- * pgbouncer_dns_hosts_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_dns_hosts_func() RETURNS TABLE 
-( 
-    pgbouncer_target_host text
-    , hostname text
-    , ttl bigint
-    , addrs text
-)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
-BEGIN
-
-FOR v_row IN  
-    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN
-
-    RETURN QUERY SELECT 
-        v_row.target_host AS pgbouncer_target_host
-        , x.hostname
-        , x.ttl
-        , x.addrs
-    FROM dblink(v_row.target_host, 'show dns_hosts') AS x
-    (   
-        hostname text
-        , ttl bigint
-        , addrs text
-    );
-    EXCEPTION
-        WHEN connection_exception THEN
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
-            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
-                                    ex_context = PG_EXCEPTION_CONTEXT,
-                                    ex_detail = PG_EXCEPTION_DETAIL,
-                                    ex_hint = PG_EXCEPTION_HINT;
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
-ORIGINAL ERROR: %
-CONTEXT: %
-DETAIL: %
-HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
-END;
-END LOOP;
-
-END
-$$;
-
-
-/*
- * pgbouncer_dns_zones_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_dns_zones_func() RETURNS TABLE 
-( 
-    pgbouncer_target_host text
-    , zonename text
-    , serial text
-    , count int
-)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
-BEGIN
-
-FOR v_row IN  
-    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN
-
-    RETURN QUERY SELECT 
-        v_row.target_host AS pgbouncer_target_host
-        , x.zonename
-        , x.serial
-        , x.count
-    FROM dblink(v_row.target_host, 'show dns_zones') AS x
-    (   
-        zonename text
-        , serial text
-        , count int
-    );
-    EXCEPTION
-        WHEN connection_exception THEN
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
-            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
-                                    ex_context = PG_EXCEPTION_CONTEXT,
-                                    ex_detail = PG_EXCEPTION_DETAIL,
-                                    ex_hint = PG_EXCEPTION_HINT;
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
-ORIGINAL ERROR: %
-CONTEXT: %
-DETAIL: %
-HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
-END;
-END LOOP;
-
-END
-$$;
-
-
-/*
- * pgbouncer_lists_func
- */ 
-CREATE FUNCTION @extschema@.pgbouncer_lists_func() RETURNS TABLE 
-( 
-    pgbouncer_target_host text
-    , list text
-    , items int
-)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
-BEGIN
-
-FOR v_row IN  
-    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN
-
-    RETURN QUERY SELECT 
-        v_row.target_host AS pgbouncer_target_host
-        , x.list
-        , x.items
-    FROM dblink(v_row.target_host, 'show lists') AS x
-    (   
-        list text
-        , items int
-    );
-    EXCEPTION
-        WHEN connection_exception THEN
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
-            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
-                                    ex_context = PG_EXCEPTION_CONTEXT,
-                                    ex_detail = PG_EXCEPTION_DETAIL,
-                                    ex_hint = PG_EXCEPTION_HINT;
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
-ORIGINAL ERROR: %
-CONTEXT: %
-DETAIL: %
-HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
-END;
-END LOOP;
-
-END
-$$;
-
-
-/*
- * pgbouncer_pools_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_pools_func() RETURNS TABLE 
-( 
-    pgbouncer_target_host text
-    , database text
-    , "user" text
-    , cl_active int
-    , cl_waiting int
-    , cl_active_cancel_req int
-    , cl_waiting_cancel_req int
-    , sv_active int
-    , sv_active_cancel int
-    , sv_being_canceled int
-    , sv_idle int
-    , sv_used int
-    , sv_tested int
-    , sv_login int
-    , maxwait int
-    , maxwait_us int
-    , pool_mode text
-)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
-    v_version_major     int;
-    v_version_minor     int;
-BEGIN
-
-FOR v_row IN  
-    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN
-
-    SELECT version_major, version_minor
-    INTO v_version_major, v_version_minor
-    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
-  
-    IF v_version_major >= 1 AND v_version_minor >= 18 THEN 
-        RETURN QUERY SELECT 
-               v_row.target_host AS pgbouncer_target_host
-               , x.database
-               , x."user"
-               , x.cl_active
-               , x.cl_waiting
-               , x.cl_active_cancel_req
-               , x.cl_waiting_cancel_req
-               , x.sv_active
-               , x.sv_active_cancel
-               , x.sv_being_canceled
-               , x.sv_idle
-               , x.sv_used
-               , x.sv_tested
-               , x.sv_login
-               , x.maxwait
-               , x.maxwait_us
-               , x.pool_mode
-        FROM dblink(v_row.target_host, 'show pools') AS x
-        (   database text
-            , "user" text
-            , cl_active int
-            , cl_waiting int
-            , cl_active_cancel_req int
-            , cl_waiting_cancel_req int
-            , sv_active int
-            , sv_active_cancel int
-            , sv_being_canceled int
-            , sv_idle int
-            , sv_used int
-            , sv_tested int
-            , sv_login int
-            , maxwait int
-            , maxwait_us int
-            , pool_mode text
-        );
-    -- backward compatiblity floor is 1.17
-    -- old cl_cancel_req is sent as cl_waiting_cancel_req
-    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
-        RETURN QUERY SELECT 
-               v_row.target_host AS pgbouncer_target_host
-               , x.database
-               , x."user"
-               , x.cl_active
-               , x.cl_waiting
-               , 0 AS cl_active_cancel_req
-               , x.cl_cancel_req AS cl_waiting_cancel_req
-               , x.sv_active
-               , 0 AS sv_active_cancel
-               , 0 AS sv_being_canceled
-               , x.sv_idle
-               , x.sv_used
-               , x.sv_tested
-               , x.sv_login
-               , x.maxwait
-               , x.maxwait_us
-               , x.pool_mode
-        FROM dblink(v_row.target_host, 'show pools') AS x
-        (   database text
-            , "user" text
-            , cl_active int
-            , cl_waiting int
-            , cl_cancel_req int
-            , sv_active int
-            , sv_idle int
-            , sv_used int
-            , sv_tested int
-            , sv_login int
-            , maxwait int
-            , maxwait_us int
-            , pool_mode text
-        );
-    ELSE
-        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
-    END IF;
-    EXCEPTION
-        WHEN connection_exception THEN
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
-            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
-                                    ex_context = PG_EXCEPTION_CONTEXT,
-                                    ex_detail = PG_EXCEPTION_DETAIL,
-                                    ex_hint = PG_EXCEPTION_HINT;
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
-ORIGINAL ERROR: %
-CONTEXT: %
-DETAIL: %
-HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
-END;
-END LOOP;
-
-END
-$$;
-
-
-/*
- * pgbouncer_servers_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_servers_func() RETURNS TABLE 
-( 
-    pgbouncer_target_host text
-    , "type" text
-    , "user" text
-    , database text
-    , replication text
-    , state text
-    , addr text
-    , port int
-    , local_addr text
-    , local_port int
-    , connect_time timestamp with time zone
-    , request_time timestamp with time zone
-    , wait int
-    , wait_us int
-    , close_needed int
-    , ptr text
-    , link text
-    , remote_pid int
-    , tls text
-    , application_name text
-    , prepared_statements int
-)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row               record;
-    v_version_major     int;
-    v_version_minor     int;
-BEGIN
-
-FOR v_row IN  
-    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN
-
-    SELECT version_major, version_minor
-    INTO v_version_major, v_version_minor
-    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
-
-    IF v_version_major >= 1 AND v_version_minor >= 23 THEN
-        RETURN QUERY SELECT
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , x.replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , x.application_name
-            , x.prepared_statements
-        FROM dblink(v_row.target_host, 'show servers') AS x
-        (
-            "type" text
-            , "user" text
-            , database text
-            , replication text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-            , application_name text
-            , prepared_statements int
-        );
-    ELSIF v_version_major = 1 AND v_version_minor >= 21 and v_version_minor < 23 THEN
-        RETURN QUERY SELECT 
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , '' AS replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , x.application_name
-            , x.prepared_statements
-        FROM dblink(v_row.target_host, 'show servers') AS x
-        (   
-            "type" text
-            , "user" text
-            , database text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-            , application_name text
-            , prepared_statements int
-        );
-    ELSIF v_version_major = 1 AND v_version_minor >= 18 and v_version_minor < 21 THEN
-        RETURN QUERY SELECT 
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , '' AS replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , x.application_name
-            , 0 AS prepared_statements
-        FROM dblink(v_row.target_host, 'show servers') AS x
-        (   
-            "type" text
-            , "user" text
-            , database text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-            , application_name text
-        );
-    -- backward compatiblity floor is 1.17
-    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
-        RETURN QUERY SELECT 
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , '' AS replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , '' AS application_name
-            , 0 AS prepared_statements
-        FROM dblink(v_row.target_host, 'show servers') AS x
-        (   
-            "type" text
-            , "user" text
-            , database text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-        );
-    ELSE
-        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
-    END IF;
-    EXCEPTION
-        WHEN connection_exception THEN
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
-            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
-                                    ex_context = PG_EXCEPTION_CONTEXT,
-                                    ex_detail = PG_EXCEPTION_DETAIL,
-                                    ex_hint = PG_EXCEPTION_HINT;
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
-ORIGINAL ERROR: %
-CONTEXT: %
-DETAIL: %
-HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
-END;
-END LOOP;
-
-END
-$$;
-
-
-/*
- * pgbouncer_sockets_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_sockets_func() RETURNS TABLE 
-( 
-    pgbouncer_target_host text
-    , "type" text
-    , "user" text
-    , database text
-    , replication text
-    , state text
-    , addr text
-    , port int
-    , local_addr text
-    , local_port int
-    , connect_time timestamp with time zone
-    , request_time timestamp with time zone
-    , wait int
-    , wait_us int
-    , close_needed int
-    , ptr text
-    , link text
-    , remote_pid int
-    , tls text
-    , application_name text
-    , recv_pos int
-    , pkt_pos int
-    , pkt_remain int
-    , send_pos int
-    , send_remain int
-    , pkt_avail int
-    , send_avail int
-    , prepared_statements int
-)
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row               record;
-    v_version_major     int;
-    v_version_minor     int;
-BEGIN
-
-FOR v_row IN  
-    SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
-LOOP BEGIN
-    SELECT version_major, version_minor
-    INTO v_version_major, v_version_minor
-    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
-  
-    IF v_version_major >= 1 AND v_version_minor >= 23 THEN
-        RETURN QUERY SELECT
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , x.replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , x.application_name
-            , x.recv_pos
-            , x.pkt_pos
-            , x.pkt_remain
-            , x.send_pos
-            , x.send_remain
-            , x.pkt_avail
-            , x.send_avail
-            , x.prepared_statements
-        FROM dblink(v_row.target_host, 'show sockets') AS x
-        (
-            "type" text
-            , "user" text
-            , database text
-            , replication text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-            , application_name text
-            , recv_pos int
-            , pkt_pos int
-            , pkt_remain int
-            , send_pos int
-            , send_remain int
-            , pkt_avail int
-            , send_avail int
-            , prepared_statements int
-        );
-    ELSIF v_version_major = 1 AND v_version_minor >= 21 AND v_version_minor < 23 THEN
-        RETURN QUERY SELECT 
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , '' AS replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , x.application_name
-            , x.recv_pos
-            , x.pkt_pos
-            , x.pkt_remain
-            , x.send_pos
-            , x.send_remain
-            , x.pkt_avail
-            , x.send_avail
-            , x.prepared_statements
-        FROM dblink(v_row.target_host, 'show sockets') AS x
-        (   
-            "type" text
-            , "user" text
-            , database text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-            , application_name text
-            , recv_pos int
-            , pkt_pos int
-            , pkt_remain int
-            , send_pos int
-            , send_remain int
-            , pkt_avail int
-            , send_avail int
-            , prepared_statements int
-        );
-    ELSIF v_version_major = 1 AND v_version_minor >= 18 AND v_version_minor < 21 THEN 
-        RETURN QUERY SELECT 
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , '' AS replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , x.application_name
-            , x.recv_pos
-            , x.pkt_pos
-            , x.pkt_remain
-            , x.send_pos
-            , x.send_remain
-            , x.pkt_avail
-            , x.send_avail
-            , 0 AS prepared_statements
-        FROM dblink(v_row.target_host, 'show sockets') AS x
-        (   
-            "type" text
-            , "user" text
-            , database text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-            , application_name text
-            , recv_pos int
-            , pkt_pos int
-            , pkt_remain int
-            , send_pos int
-            , send_remain int
-            , pkt_avail int
-            , send_avail int
-        );
-    -- backward compatiblity floor is 1.17
-    ELSIF v_version_major = 1 AND v_version_minor = 17 THEN 
-        RETURN QUERY SELECT 
-            v_row.target_host AS pgbouncer_target_host
-            , x."type"
-            , x."user"
-            , x.database
-            , '' AS replication
-            , x.state
-            , x.addr
-            , x.port
-            , x.local_addr
-            , x.local_port
-            , x.connect_time
-            , x.request_time
-            , x.wait
-            , x.wait_us
-            , x.close_needed
-            , x.ptr
-            , x.link
-            , x.remote_pid
-            , x.tls
-            , '' AS application_name
-            , x.recv_pos
-            , x.pkt_pos
-            , x.pkt_remain
-            , x.send_pos
-            , x.send_remain
-            , x.pkt_avail
-            , x.send_avail
-            , 0 AS prepared_statements
-        FROM dblink(v_row.target_host, 'show sockets') AS x
-        (   
-            "type" text
-            , "user" text
-            , database text
-            , state text
-            , addr text
-            , port int
-            , local_addr text
-            , local_port int
-            , connect_time timestamp with time zone
-            , request_time timestamp with time zone
-            , wait int
-            , wait_us int
-            , close_needed int
-            , ptr text
-            , link text
-            , remote_pid int
-            , tls text
-            , recv_pos int
-            , pkt_pos int
-            , pkt_remain int
-            , send_pos int
-            , send_remain int
-            , pkt_avail int
-            , send_avail int
-        );
-    ELSE
-        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
-    END IF;
-    EXCEPTION
-        WHEN connection_exception THEN
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
-            GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
-                                    ex_context = PG_EXCEPTION_CONTEXT,
-                                    ex_detail = PG_EXCEPTION_DETAIL,
-                                    ex_hint = PG_EXCEPTION_HINT;
-            RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.
-ORIGINAL ERROR: %
-CONTEXT: %
-DETAIL: %
-HINT: %', v_row.target_host, ex_message, ex_context, ex_detail, ex_hint;
-END;
-END LOOP;
-
-END
-$$;
-
-
-/*
- * pgbouncer_stats_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE 
-( 
+CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE
+(
     pgbouncer_target_host text
     , database text
     , total_server_assignment_count bigint
@@ -1365,7 +1034,7 @@ DECLARE
     v_row       record;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
 
@@ -1465,11 +1134,9 @@ END LOOP;
 END
 $$;
 
-/*
- * pgbouncer_users_func
- */
-CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE 
-( 
+
+CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE
+(
     pgbouncer_target_host text
     , name text
     , pool_size text
@@ -1487,7 +1154,7 @@ DECLARE
     v_row       record;
 BEGIN
 
-FOR v_row IN  
+FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
@@ -1537,125 +1204,150 @@ END
 $$;
 
 
-/**** ADMIN FUNCTIONS ****/
+CREATE VIEW @extschema@.pgbouncer_clients AS
+    SELECT pgbouncer_target_host
+        , "type"
+        , "user"
+        , database
+        , replication
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+        , prepared_statements
+    FROM @extschema@.pgbouncer_clients_func();
 
-CREATE FUNCTION @extschema@.pgbouncer_command_disable(p_dbname text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
+
+CREATE VIEW @extschema@.pgbouncer_servers AS
+    SELECT pgbouncer_target_host
+        , "type"
+        , "user"
+        , database
+        , replication
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+        , prepared_statements
+     FROM @extschema@.pgbouncer_servers_func();
+
+
+CREATE VIEW @extschema@.pgbouncer_sockets AS
+    SELECT pgbouncer_target_host
+        , "type"
+        , "user"
+        , database
+        , replication
+        , state
+        , addr
+        , port
+        , local_addr
+        , local_port
+        , connect_time
+        , request_time
+        , wait
+        , wait_us
+        , close_needed
+        , ptr
+        , link
+        , remote_pid
+        , tls
+        , application_name
+        , recv_pos
+        , pkt_pos
+        , pkt_remain
+        , send_pos
+        , send_remain
+        , pkt_avail
+        , send_avail
+        , prepared_statements
+     FROM @extschema@.pgbouncer_sockets_func();
+
+
+CREATE VIEW @extschema@.pgbouncer_databases AS
+    SELECT pgbouncer_target_host
+        , name
+        , host
+        , port
+        , database
+        , force_user
+        , pool_size
+        , min_pool_size
+        , reserve_pool
+        , server_lifetime
+        , pool_mode
+        , max_connections
+        , current_connections
+        , paused
+        , disabled
+     FROM @extschema@.pgbouncer_databases_func();
+
+
+CREATE VIEW @extschema@.pgbouncer_stats AS
+    SELECT pgbouncer_target_host
+        , database
+        , total_server_assignment_count
+        , total_xact_count
+        , total_query_count
+        , total_received
+        , total_sent
+        , total_xact_time
+        , total_query_time
+        , total_wait_time
+        , avg_server_assignment_count
+        , avg_xact_count
+        , avg_query_count
+        , avg_recv
+        , avg_sent
+        , avg_xact_time
+        , avg_query_time
+        , avg_wait_time
+     FROM @extschema@.pgbouncer_stats_func();
+
+
+CREATE VIEW @extschema@.pgbouncer_users AS
+    SELECT pgbouncer_target_host
+        , name
+        , pool_size
+        , pool_mode
+        , max_user_connections
+        , current_connections
+     FROM @extschema@.pgbouncer_users_func();
+
+
+-- Restore dropped object privileges
+DO $$
+DECLARE
+v_row   record;
 BEGIN
-    PERFORM dblink_exec(p_pgbouncer_target_host, format('DISABLE %I', p_dbname));
+    FOR v_row IN SELECT statement FROM pgbouncer_fdw_preserve_privs_temp LOOP
+        IF v_row.statement IS NOT NULL THEN
+            EXECUTE v_row.statement;
+        END IF;
+    END LOOP;
 END
 $$;
 
-CREATE FUNCTION @extschema@.pgbouncer_command_enable(p_dbname text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    PERFORM dblink_exec(p_pgbouncer_target_host, format('ENABLE %I', p_dbname));
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_kill(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    IF p_dbname IS NULL THEN
-        PERFORM dblink_exec(p_pgbouncer_target_host, 'KILL');
-    ELSE
-        PERFORM dblink_exec(p_pgbouncer_target_host, format('KILL %I', p_dbname));
-    END IF;
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_pause(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    IF p_dbname IS NULL THEN
-        PERFORM dblink_exec(p_pgbouncer_target_host, 'PAUSE');
-    ELSE
-        PERFORM dblink_exec(p_pgbouncer_target_host, format('PAUSE %I', p_dbname));
-    END IF;
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_reconnect(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    IF p_dbname IS NULL THEN
-        PERFORM dblink_exec(p_pgbouncer_target_host, 'RECONNECT');
-    ELSE
-        PERFORM dblink_exec(p_pgbouncer_target_host, format('RECONNECT %I', p_dbname));
-    END IF;
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_reload(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    PERFORM dblink_exec(p_pgbouncer_target_host, 'RELOAD');
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_resume(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    IF p_dbname IS NULL THEN
-        PERFORM dblink_exec(p_pgbouncer_target_host, 'RESUME');
-    ELSE
-        PERFORM dblink_exec(p_pgbouncer_target_host, format('RESUME %I', p_dbname));
-    END IF;
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_set(p_name text, p_value text, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    PERFORM dblink_exec(p_pgbouncer_target_host, format('SET %s = %L', p_name, p_value));
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_shutdown(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    PERFORM dblink_exec(p_pgbouncer_target_host, 'shutdown');
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_suspend(p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    PERFORM dblink_exec(p_pgbouncer_target_host, 'SUSPEND');
-END
-$$;
-
-CREATE FUNCTION @extschema@.pgbouncer_command_wait_close(p_dbname text DEFAULT NULL, p_pgbouncer_target_host text DEFAULT 'pgbouncer') RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    IF p_dbname IS NULL THEN
-        PERFORM dblink_exec(p_pgbouncer_target_host, 'WAIT_CLOSE');
-    ELSE
-        PERFORM dblink_exec(p_pgbouncer_target_host, format('WAIT_CLOSE %I', p_dbname));
-    END IF;
-END
-$$;
-
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_disable(text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_enable(text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_kill(text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_pause(text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reconnect(text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_reload(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_resume(text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_set(text, text, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_shutdown(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_suspend(text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION @extschema@.pgbouncer_command_wait_close(text, text) FROM PUBLIC;
-
+DROP TABLE IF EXISTS pgbouncer_fdw_preserve_privs_temp;

--- a/updates/pgbouncer_fdw--1.1.0--1.2.0.sql
+++ b/updates/pgbouncer_fdw--1.1.0--1.2.0.sql
@@ -5,6 +5,7 @@ SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_cli
 FROM information_schema.table_privileges
 WHERE table_schema = '@extschema@'
 AND table_name = 'pgbouncer_clients'
+AND grantee != 'PUBLIC'
 GROUP BY grantee;
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
@@ -12,6 +13,7 @@ SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_ser
 FROM information_schema.table_privileges
 WHERE table_schema = '@extschema@'
 AND table_name = 'pgbouncer_servers'
+AND grantee != 'PUBLIC'
 GROUP BY grantee;
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
@@ -19,6 +21,7 @@ SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_soc
 FROM information_schema.table_privileges
 WHERE table_schema = '@extschema@'
 AND table_name = 'pgbouncer_sockets'
+AND grantee != 'PUBLIC'
 GROUP BY grantee;
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
@@ -26,6 +29,7 @@ SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_dat
 FROM information_schema.table_privileges
 WHERE table_schema = '@extschema@'
 AND table_name = 'pgbouncer_databases'
+AND grantee != 'PUBLIC'
 GROUP BY grantee;
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
@@ -33,6 +37,7 @@ SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_sta
 FROM information_schema.table_privileges
 WHERE table_schema = '@extschema@'
 AND table_name = 'pgbouncer_stats'
+AND grantee != 'PUBLIC'
 GROUP BY grantee;
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
@@ -40,6 +45,7 @@ SELECT 'GRANT '||string_agg(privilege_type, ',')||' ON @extschema@.pgbouncer_use
 FROM information_schema.table_privileges
 WHERE table_schema = '@extschema@'
 AND table_name = 'pgbouncer_users'
+AND grantee != 'PUBLIC'
 GROUP BY grantee;
 
 DROP VIEW @extschema@.pgbouncer_clients;
@@ -53,37 +59,43 @@ INSERT INTO pgbouncer_fdw_preserve_privs_temp
 SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_clients_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';' 
 FROM information_schema.routine_privileges
 WHERE routine_schema = '@extschema@'
-AND routine_name = 'pgbouncer_clients_func';
+AND routine_name = 'pgbouncer_clients_func'
+AND grantee != 'PUBLIC';
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp 
 SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_servers_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';' 
 FROM information_schema.routine_privileges
 WHERE routine_schema = '@extschema@'
-AND routine_name = 'pgbouncer_servers_func';
+AND routine_name = 'pgbouncer_servers_func'
+AND grantee != 'PUBLIC';
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp 
 SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_sockets_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';' 
 FROM information_schema.routine_privileges
 WHERE routine_schema = '@extschema@'
-AND routine_name = 'pgbouncer_sockets_func';
+AND routine_name = 'pgbouncer_sockets_func'
+AND grantee != 'PUBLIC';
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
 SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_databases_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';'
 FROM information_schema.routine_privileges
 WHERE routine_schema = '@extschema@'
-AND routine_name = 'pgbouncer_databases_func';
+AND routine_name = 'pgbouncer_databases_func'
+AND grantee != 'PUBLIC';
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
 SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_stats_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';'
 FROM information_schema.routine_privileges
 WHERE routine_schema = '@extschema@'
-AND routine_name = 'pgbouncer_stats_func';
+AND routine_name = 'pgbouncer_stats_func'
+AND grantee != 'PUBLIC';
 
 INSERT INTO pgbouncer_fdw_preserve_privs_temp
 SELECT 'GRANT EXECUTE ON FUNCTION @extschema@.pgbouncer_users_func()  TO '||array_to_string(array_agg('"'||grantee::text||'"'), ',')||';'
 FROM information_schema.routine_privileges
 WHERE routine_schema = '@extschema@'
-AND routine_name = 'pgbouncer_users_func';
+AND routine_name = 'pgbouncer_users_func'
+AND grantee != 'PUBLIC';
 
 DROP FUNCTION @extschema@.pgbouncer_clients_func();
 DROP FUNCTION @extschema@.pgbouncer_servers_func();

--- a/updates/pgbouncer_fdw--1.1.0--1.2.0.sql
+++ b/updates/pgbouncer_fdw--1.1.0--1.2.0.sql
@@ -918,16 +918,22 @@ CREATE FUNCTION @extschema@.pgbouncer_databases_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
+    ex_context          text;
+    ex_detail           text;
+    ex_hint             text;
+    ex_message          text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
 
 FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
 
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
         RETURN QUERY SELECT
@@ -996,6 +1002,9 @@ LOOP BEGIN
             , paused int
             , disabled int
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
     EXCEPTION
         WHEN connection_exception THEN
             RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
@@ -1039,16 +1048,22 @@ CREATE FUNCTION @extschema@.pgbouncer_stats_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
+    ex_context          text;
+    ex_detail           text;
+    ex_hint             text;
+    ex_message          text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
 
 FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
 
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
         RETURN QUERY SELECT
@@ -1128,6 +1143,9 @@ LOOP BEGIN
             , avg_query_time bigint
             , avg_wait_time bigint
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
     EXCEPTION
         WHEN connection_exception THEN
             RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;
@@ -1159,16 +1177,23 @@ CREATE FUNCTION @extschema@.pgbouncer_users_func() RETURNS TABLE
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    ex_context                      text;
-    ex_detail                       text;
-    ex_hint                         text;
-    ex_message                      text;
-    v_row       record;
+    ex_context          text;
+    ex_detail           text;
+    ex_hint             text;
+    ex_message          text;
+    v_row               record;
+    v_version_major     int;
+    v_version_minor     int;
 BEGIN
 
 FOR v_row IN
     SELECT target_host FROM @extschema@.pgbouncer_fdw_targets WHERE active
 LOOP BEGIN
+
+    SELECT version_major, version_minor
+    INTO v_version_major, v_version_minor
+    FROM @extschema@.pgbouncer_version_func(v_row.target_host);
+
     IF v_version_major >= 1 AND v_version_minor >= 23 THEN
         RETURN QUERY SELECT
             v_row.target_host AS pgbouncer_target_host
@@ -1198,6 +1223,9 @@ LOOP BEGIN
             name text
             , pool_mode text
         );
+    ELSE
+        RAISE EXCEPTION 'Encountered unsupported version of PgBouncer: %.%.x', v_version_major, v_version_minor;
+    END IF;
     EXCEPTION
         WHEN connection_exception THEN
             RAISE WARNING 'pgbouncer_fdw: Unable to establish connection to pgBouncer target host: %. Continuing to additional hosts.', v_row.target_host;


### PR DESCRIPTION
PgBouncer 1.23 added several new columns were added across various SHOW commands.
 - Adds `replication` column to clients, servers, and sockets functions and views.
 - Adds `server_lifetime` column to databases functions and views.
 - Adds `total_server_assignment_count` and `avg_server_assignment_count` columns to stats functions and views.
 - Adds `pool_size`, `max_user_connections`, and `current_connections` columns to users functions and views.